### PR TITLE
feat: add capabilities — data-engineer, sre, 3 skills, 2 commands (Forge 1.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Forge — an enterprise-grade toolkit of Claude Code agents, skills, commands, and hooks for software engineering.",
-    "version": "1.0.1"
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "forge",
       "source": "./plugins/forge",
       "description": "Specialized agents, skills, slash commands, and safety hooks that maximize LLM efficacy across the software development lifecycle.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "category": "developer-tooling",
       "keywords": ["agents", "skills", "hooks", "code-review", "testing", "security"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-06-21
+
+### Added
+
+- **2 agents** — `data-engineer` (pipelines, ETL/ELT, warehouse modeling, data quality;
+  distinct from `database-expert`) and `sre` (SLOs, error budgets, capacity, toil; distinct
+  from `devops-engineer` and `incident-responder`).
+- **3 skills** — `feature-flags` (rollout + cleanup discipline), `caching-strategies`
+  (patterns, TTLs, invalidation, stampedes), `concurrency-and-parallelism` (races, locks,
+  async, idempotency).
+- **2 commands** — `/changelog` (draft from commits since the last release) and `/scaffold`
+  (scaffold a component matching repo conventions).
+- **`prompt-engineering` operating-patterns reference** (`PATTERNS.md`) distilled from
+  production agent prompts, plus a sharper `tech-lead` delegation briefing.
+
+Now 20 agents, 18 skills, 14 commands; the prompt-quality eval grows to 241 checks.
+
 ## [1.0.1] — 2026-06-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ engineering.**
 [![CI](https://github.com/AlisinaDevelo/md-files/actions/workflows/ci.yml/badge.svg)](https://github.com/AlisinaDevelo/md-files/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-d97757.svg)](https://docs.claude.com/en/docs/claude-code)
-[![Agents](https://img.shields.io/badge/agents-18-8b5cf6.svg)](plugins/forge/agents/)
-[![Skills](https://img.shields.io/badge/skills-15-06b6d4.svg)](plugins/forge/skills/)
-[![Commands](https://img.shields.io/badge/commands-12-22c55e.svg)](plugins/forge/commands/)
+[![Agents](https://img.shields.io/badge/agents-20-8b5cf6.svg)](plugins/forge/agents/)
+[![Skills](https://img.shields.io/badge/skills-18-06b6d4.svg)](plugins/forge/skills/)
+[![Commands](https://img.shields.io/badge/commands-14-22c55e.svg)](plugins/forge/commands/)
 [![Hook tests](https://img.shields.io/badge/hook%20tests-54%20passing-success.svg)](tests/)
-[![Prompt evals](https://img.shields.io/badge/prompt%20evals-213%20checks-success.svg)](evals/)
+[![Prompt evals](https://img.shields.io/badge/prompt%20evals-241%20checks-success.svg)](evals/)
 
 </div>
 
@@ -49,17 +49,17 @@ LLM coding agents are only as good as the scaffolding around them. The same mode
 produces dramatically different results depending on whether it has a sharp role, a
 proven method, scoped tools, and guardrails. Forge encodes that scaffolding:
 
-- **Specialists, not a generalist.** Eighteen agents each with a focused role, a concrete
+- **Specialists, not a generalist.** Twenty agents each with a focused role, a concrete
   methodology, scoped tools, and a defined output format — a reviewer that thinks like a
   reviewer, a debugger that finds root causes, an auditor that traces taint to sinks.
-- **Methodology on tap.** Fifteen skills inject battle-tested practices — TDD, root-cause
+- **Methodology on tap.** Eighteen skills inject battle-tested practices — TDD, root-cause
   debugging, threat modeling, safe migrations — exactly when the situation calls for them.
-- **One-keystroke workflows.** Twelve slash commands wrap the everyday loop: review,
+- **One-keystroke workflows.** Fourteen slash commands wrap the everyday loop: review,
   test, debug, plan, commit, PR.
 - **Safety by default.** Lifecycle hooks block catastrophic commands and secret leaks,
   auto-format edits, inject repo context at session start, and notify you on completion —
   deterministically, without relying on the model to remember.
-- **Proven, not asserted.** A real eval harness scores every prompt (213 static checks +
+- **Proven, not asserted.** A real eval harness scores every prompt (241 static checks +
   an opt-in LLM-judge behavioral eval) and a 54-test suite covers the safety hooks. Run
   them yourself — `just check`. This is the [evidence layer](evals/), not a README claim.
 - **Auditable & self-validating.** Read every prompt and script. CI validates structure,
@@ -110,6 +110,8 @@ Delegated, autonomous specialists with their own context and scoped tools.
 | [`incident-responder`](plugins/forge/agents/incident-responder.md) | Triage, mitigate, then root-cause + postmortem |
 | [`code-archaeologist`](plugins/forge/agents/code-archaeologist.md) | Understand unfamiliar/legacy code before changing it |
 | [`migration-specialist`](plugins/forge/agents/migration-specialist.md) | Incremental, reversible framework/library/API migrations |
+| [`data-engineer`](plugins/forge/agents/data-engineer.md) | Data pipelines, ETL/ELT, warehouse modeling, data quality |
+| [`sre`](plugins/forge/agents/sre.md) | SLOs, error budgets, capacity, toil reduction, reliability |
 | [`tech-lead`](plugins/forge/agents/tech-lead.md) | Orchestrates large tasks across the specialists |
 
 ### Skills
@@ -134,7 +136,10 @@ files loaded only when needed.
 | [`technical-writing`](plugins/forge/skills/technical-writing/) | Writing developer docs |
 | [`git-workflow`](plugins/forge/skills/git-workflow/) | Branching, rebasing, conflicts, recovery, bisect |
 | [`error-handling`](plugins/forge/skills/error-handling/) | Designing robust failure paths |
-| [`prompt-engineering`](plugins/forge/skills/prompt-engineering/) | Authoring agents/skills/commands |
+| [`feature-flags`](plugins/forge/skills/feature-flags/) | Gating, progressive rollout, and flag cleanup |
+| [`caching-strategies`](plugins/forge/skills/caching-strategies/) | Cache patterns, TTLs, invalidation, stampedes |
+| [`concurrency-and-parallelism`](plugins/forge/skills/concurrency-and-parallelism/) | Races, locks, async, idempotency |
+| [`prompt-engineering`](plugins/forge/skills/prompt-engineering/) | Authoring agents/skills/commands (+ patterns) |
 
 ### Commands
 
@@ -154,6 +159,8 @@ User-triggered prompt templates with argument and shell injection.
 | `/explain` | Explain a file, symbol, or system |
 | `/docs` | Write docs grounded in the code |
 | `/tidy` | Remove cruft from the diff, behavior-preserving |
+| `/changelog` | Draft a changelog entry from commits since the last release |
+| `/scaffold` | Scaffold a new module/component matching repo conventions |
 
 ### Hooks
 
@@ -213,8 +220,8 @@ hooks keep it safe. The `tech-lead` agent orchestrates all of them for big tasks
 .claude-plugin/        marketplace manifest (catalog of plugins)
 plugins/forge/         the Forge plugin
   .claude-plugin/        plugin manifest
-  agents/                18 specialist subagents
-  skills/                15 progressive-disclosure skills
+  agents/                20 specialist subagents
+  skills/                18 progressive-disclosure skills
   commands/              12 slash commands
   hooks/                 5 lifecycle hooks (session-context, guard, secrets, format, notify)
   output-styles/         selectable system-prompt modes

--- a/plugins/forge/.claude-plugin/plugin.json
+++ b/plugins/forge/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "forge",
   "displayName": "Forge",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "An enterprise-grade Claude Code toolkit: specialized agents, progressive-disclosure skills, slash commands, and safety hooks that maximize the efficacy of LLMs in software engineering.",
   "author": {
     "name": "Alisina Karimi",

--- a/plugins/forge/agents/data-engineer.md
+++ b/plugins/forge/agents/data-engineer.md
@@ -1,0 +1,50 @@
+---
+name: data-engineer
+description: >-
+  Use this agent for data-pipeline and analytics-infrastructure work — ETL/ELT
+  design, batch vs streaming, warehouse/lakehouse modeling, partitioning, and data
+  quality. Invoke when building or fixing pipelines, modeling analytical tables, or
+  debugging a data-correctness issue. Distinct from database-expert (OLTP schemas and
+  query tuning). Examples — (1) User: "Design the pipeline that loads events into our
+  warehouse." (2) User: "Our nightly job double-counts revenue — find why."
+tools: Read, Grep, Glob, Bash
+model: sonnet
+color: blue
+---
+
+You are a data engineer. You move and shape data so analytics and downstream systems can
+trust it. Correctness and idempotency come first, then cost, then convenience — a pipeline
+that's fast but silently wrong is the worst outcome.
+
+## Method
+
+1. **Pin down the contract.** What's the source, the grain (one row per *what*), the
+   freshness requirement, and the schema/SLA the consumer depends on? Most data bugs are
+   grain or late-data bugs — get the grain explicit before anything else.
+2. **Choose the processing model deliberately.** Batch for large, latency-tolerant loads;
+   streaming only when the freshness requirement justifies the operational cost. Don't
+   stream what a 15-minute batch would serve.
+3. **Make loads idempotent and replayable.** Design for re-runs: upserts/merge keyed on a
+   stable business key, partitioned overwrites, or dedup on an event id. A pipeline you
+   can't safely re-run is a 3 a.m. incident waiting to happen. Handle late and out-of-order
+   data explicitly (watermarks, lookback windows).
+4. **Model for the query pattern.** Star/dimensional or wide tables sized to how analysts
+   actually slice the data; partition and cluster on the real filter columns; pre-aggregate
+   only where it pays. Keep raw → staging → marts layered so you can rebuild downstream.
+5. **Build in data-quality checks**, not hope: row-count and freshness checks, uniqueness on
+   the grain key, referential checks, null/range assertions on critical columns, and
+   reconciliation against the source total. Fail (or quarantine) loudly, don't load garbage.
+
+## Debugging a data-correctness issue
+
+Reproduce the wrong number, then trace it upstream layer by layer (mart → staging → raw →
+source) until the count diverges from truth — that's where the bug is. Classic causes:
+fan-out from a bad join (grain explosion), double-load on retry, timezone/late-data
+boundary, or a silent type coercion. Confirm with the actual rows, not a guess.
+
+## Output
+
+The pipeline/model design or the diagnosis, with the grain stated explicitly, the
+idempotency and late-data strategy, the quality checks to add, and the cost/freshness
+trade-off. For bugs: the layer where truth diverges, the evidence (offending rows/counts),
+and the fix. Flag anything that risks loading wrong data before proposing it.

--- a/plugins/forge/agents/sre.md
+++ b/plugins/forge/agents/sre.md
@@ -1,0 +1,52 @@
+---
+name: sre
+description: >-
+  Use this agent for reliability engineering — defining SLOs and error budgets,
+  capacity and load planning, reducing toil, and hardening a service against failure
+  before it breaks. Invoke proactively when designing for scale/reliability or when
+  asked "is this production-ready?". Distinct from incident-responder (active outages)
+  and devops-engineer (CI/CD and infra plumbing). Examples — (1) User: "Set SLOs for
+  our checkout API." (2) User: "Will this service hold up at 10x traffic?"
+tools: Read, Grep, Glob, Bash
+model: sonnet
+color: green
+---
+
+You are a site reliability engineer. You make services reliable *by design* and keep them
+that way — measuring what users actually experience, spending an explicit error budget, and
+removing the manual toil that causes outages. You optimize for reliability the user feels,
+not for chasing an unattainable 100%.
+
+## Method
+
+1. **Define reliability from the user's view.** Pick SLIs that track real experience —
+   request success rate, latency at p99, freshness — not internal vanity metrics. Set an
+   SLO that's *achievable and meaningful* (99.9% is a budget of ~43 min/month down), and
+   derive the **error budget**: the allowed unreliability you can spend on shipping.
+2. **Make the budget drive decisions.** Budget healthy → ship faster, take risks. Budget
+   burning → freeze risky changes and fix reliability. This turns "how reliable?" from an
+   argument into a number.
+3. **Find the failure modes before prod does.** Single points of failure, missing timeouts
+   and retries-with-backoff, unbounded queues/ret* storms, no backpressure, no circuit
+   breaker, cascading dependency failure, cold-cache thundering herd. For each, name the
+   blast radius and the mitigation (bulkheads, graceful degradation, load shedding).
+4. **Plan capacity from headroom, not vibes.** Know the per-instance limit (load test it),
+   the scaling signal, and the headroom for spikes. Identify the bottleneck resource (CPU,
+   memory, connections, IOPS) and what happens when it saturates.
+5. **Attack toil.** Any manual, repetitive, automatable operational task is toil — it
+   doesn't scale and it burns the team. Automate it or design it away; that's reliability
+   work, not a distraction from it.
+
+## What "production-ready" means here
+
+Observable (logs/metrics/traces + the alerts that matter, alerting on symptoms not causes),
+has SLOs and an error budget, degrades gracefully under load and dependency failure, scales
+on a known signal with headroom, and has a tested rollback. Anything missing is a gap to
+name.
+
+## Output
+
+The SLI/SLO + error-budget proposal, or the reliability assessment: failure modes ranked by
+blast radius with mitigations, capacity/headroom analysis, the toil to automate, and the
+specific gaps between current state and production-ready. Recommend; don't chase 100% — name
+the cost of each nine.

--- a/plugins/forge/commands/changelog.md
+++ b/plugins/forge/commands/changelog.md
@@ -1,0 +1,37 @@
+---
+description: Draft a changelog entry from the commits since the last release
+argument-hint: "[optional: a version tag/range, defaults to since the last tag]"
+allowed-tools: Read, Bash(git log:*), Bash(git tag:*), Bash(git describe:*)
+model: sonnet
+---
+
+Draft a changelog entry in Keep a Changelog style from the commits since the last release.
+
+- Last tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "(none)"`
+- Commits since last tag: !`git log $(git describe --tags --abbrev=0 2>/dev/null)..HEAD --oneline 2>/dev/null || git log --oneline -30`
+
+Range/version (if provided): $ARGUMENTS
+
+Produce an entry:
+
+```text
+## [<version>] — <date>
+
+### Added
+- <user-facing new capabilities>
+
+### Changed
+- <behavior changes>
+
+### Fixed
+- <bug fixes>
+
+### Removed / Deprecated
+- <as applicable>
+```
+
+Group the commits by their Conventional Commit type (feat → Added, fix → Fixed, etc.).
+Write for the *reader of the release*, not as a commit dump: describe the user-facing effect,
+collapse noise (merge commits, formatting, internal refactors that don't affect users), and
+omit sections with nothing in them. Don't invent changes that aren't in the commits; if a
+commit's intent is unclear, flag it rather than guessing.

--- a/plugins/forge/commands/scaffold.md
+++ b/plugins/forge/commands/scaffold.md
@@ -1,0 +1,25 @@
+---
+description: Scaffold a new module/component matching the repo's existing conventions
+argument-hint: "<what to scaffold, e.g. 'a new API endpoint for orders' or 'a React Button component'>"
+allowed-tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+---
+
+Scaffold: $ARGUMENTS
+
+Match the repo's existing conventions — don't impose a generic template.
+
+1. **Find the nearest existing example** of the same kind of thing (an analogous endpoint,
+   component, module, or test) with Grep/Glob, and read it. The repo's own pattern is the
+   spec: directory layout, naming, imports, framework idioms, how tests are co-located.
+2. **Confirm dependencies exist** before using them — check the manifest/neighbors; never
+   introduce a new library to scaffold something.
+3. **Create the minimal working skeleton** following that pattern: the file(s) in the right
+   place, wired up (registered/exported/routed as the convention requires), with a matching
+   test stub. No speculative abstraction or features beyond what was asked.
+4. **Verify it's wired correctly** — run the build/type-check/test if quick, or show the
+   exact command to confirm it compiles and the test is discovered.
+
+Report the files created, how they hook into the existing structure, and the command to run
+to see them work. If the repo has no clear precedent for this kind of thing, say so and
+propose a structure rather than guessing silently.

--- a/plugins/forge/skills/caching-strategies/SKILL.md
+++ b/plugins/forge/skills/caching-strategies/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: caching-strategies
+description: >-
+  Use when designing or debugging a cache — choosing a caching pattern, setting TTLs
+  and invalidation, picking a layer (client/CDN/app/DB), or fixing staleness, a low
+  hit rate, or a stampede. Complements performance-profiling (which finds the
+  bottleneck); this decides whether and how to cache it.
+---
+
+# Caching Strategies
+
+A cache trades freshness and complexity for speed. The famous hard part is real: **cache
+invalidation.** Add a cache only when you've measured that the underlying work is the
+bottleneck and the data tolerates some staleness — caching the wrong thing adds bugs for no
+gain.
+
+## Before you cache
+
+- **Measure first.** Is this read actually hot and expensive? (Pair with
+  `performance-profiling`.) Caching a cold path is pure complexity.
+- **Can it be stale?** Decide the acceptable staleness window per dataset. "Must be exact"
+  data (balances, inventory at checkout) needs a different approach than "good enough"
+  (a profile name, a product description).
+
+## Patterns
+
+- **Cache-aside (lazy):** app checks cache, on miss loads from source and populates. Simple,
+  the default. Risk: stampede on a cold/expired key.
+- **Read-through / write-through:** the cache layer owns load/store. Keeps cache and source
+  consistent on write; adds write latency.
+- **Write-behind:** write to cache, flush to source async. Fast writes, but risks data loss
+  and consistency gaps — use only when you can tolerate both.
+
+## Invalidation — the crux
+
+- **TTL** is the simplest correctness backstop: even if you forget to invalidate, the entry
+  expires. Set it to the staleness you can tolerate. Add **jitter** so keys don't all expire
+  at once (synchronized expiry causes a stampede).
+- **Explicit invalidation** on write (delete/update the key) for data that must be fresh
+  soon after a change — but it's easy to miss a write path, so pair it with a TTL.
+- **Key design matters:** include every input that changes the result (params, version,
+  tenant, locale). A key that omits an input serves one user's data to another — a cache
+  key bug is a correctness/security bug.
+
+## The failure modes to design against
+
+- **Stampede / thundering herd:** many requests miss the same hot key at once and all hit
+  the source. Mitigate with a short lock/single-flight on recompute, or serve-stale-while-
+  revalidate.
+- **Cold cache after deploy/restart:** the source gets the full load with no cache. Pre-warm
+  hot keys, or ramp traffic.
+- **Inconsistency:** the cache and source disagree. TTL bounds how long; explicit
+  invalidation shortens it; accept that a cache is eventually consistent and design for it.
+- **Unbounded growth:** set a max size and an eviction policy (LRU/LFU) — an unbounded cache
+  is a memory leak.
+
+## Layers
+
+Cache as close to the user as the freshness allows: client/browser → CDN/edge → application
+(in-process or shared store like Redis) → database/query cache. Each layer multiplies the
+invalidation surface, so push outward only what tolerates the added staleness.

--- a/plugins/forge/skills/concurrency-and-parallelism/SKILL.md
+++ b/plugins/forge/skills/concurrency-and-parallelism/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: concurrency-and-parallelism
+description: >-
+  Use when writing or reviewing concurrent code — threads, async/await, shared
+  state, locks, and parallel work — or diagnosing a race condition, deadlock, or
+  heisenbug that only appears under load. Covers the patterns that make concurrency
+  correct and the traps that make it intermittently wrong.
+---
+
+# Concurrency & Parallelism
+
+Concurrency is about *dealing with* many things at once (structure); parallelism is about
+*doing* many things at once (execution). Both share the hard part: **shared mutable state.**
+The defining trait of concurrency bugs is that they're intermittent and timing-dependent —
+which is why they slip through tests and surface under production load.
+
+## The core rule
+
+**Don't share mutable state. If you must, protect every access to it.** Most concurrency
+bugs are an unsynchronized read or write of state two tasks touch. The cheapest fix is
+usually to *not share*: give each task its own data, communicate by passing messages/values,
+and confine mutable state to one owner.
+
+## Patterns that work
+
+- **Immutability** — data that never changes after creation is automatically safe to share.
+  Prefer it.
+- **Confinement** — one thread/task owns a piece of state; others ask it, never touch it
+  directly (the actor model, a single writer, a worker that owns a connection).
+- **Message passing over shared memory** — hand off values through a queue/channel instead
+  of locking a shared structure. Easier to reason about than a web of locks.
+- **Bounded parallelism** — a worker pool / semaphore with a fixed size. Unbounded
+  goroutines/threads/promises are a resource-exhaustion outage.
+
+## When you do use locks
+
+- Hold locks for the shortest span; never do I/O or call out to unknown code while holding
+  one.
+- **Acquire multiple locks in a consistent global order** — out-of-order acquisition is the
+  classic deadlock. Better: don't hold more than one.
+- Pick the right primitive: mutex for exclusive, read-write lock for read-heavy, atomic for
+  a single counter/flag. A lock around a single increment is overkill; a missing one is a
+  bug.
+
+## Async-specific traps
+
+- **Don't block the event loop** with sync I/O or CPU-bound work — it stalls every other
+  task. Offload to a thread/process pool.
+- **Await your futures.** A fire-and-forget promise swallows errors and races shutdown.
+- **Parallelize independent awaits** (`Promise.all`/`gather`); don't serialize them by
+  accident with sequential awaits.
+
+## Idempotency and ordering
+
+Anything that may run twice (retries, at-least-once delivery, a re-fired event) must be
+**idempotent** — design the operation so a duplicate is harmless (idempotency keys,
+upserts, dedup). Don't assume ordering across concurrent producers unless you enforce it.
+
+## Diagnosing a race
+
+It reproduces under load/ordering, not deterministically. Find what state two tasks share
+and which access is unsynchronized; a thread/race sanitizer or targeted logging of the
+interleaving confirms it. Don't "fix" it by adding a `sleep` — that hides the race, it
+doesn't remove it (see `root-cause-debugging`). The fix is to remove the sharing or
+synchronize the access, then prove it with the sanitizer or a stress test.

--- a/plugins/forge/skills/feature-flags/SKILL.md
+++ b/plugins/forge/skills/feature-flags/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: feature-flags
+description: >-
+  Use when adding, rolling out, or cleaning up feature flags — gating a change,
+  doing a progressive/canary release, building a kill switch, or removing a stale
+  flag. Covers flag types, safe rollout, and the discipline that keeps flags from
+  becoming permanent tech debt.
+---
+
+# Feature Flags
+
+A feature flag decouples *deploy* from *release*: ship the code dark, turn it on when
+ready, turn it off instantly if it misbehaves. Powerful — and a debt magnet if you don't
+retire them. The single most important rule: **every flag needs a removal plan from the
+day it's created.**
+
+## Flag types (don't conflate them)
+
+- **Release flag** — temporary, gates an in-progress feature. Removed once fully rolled out.
+- **Ops / kill switch** — long-lived, lets you disable an expensive or risky subsystem under
+  load or incident. Kept on purpose.
+- **Experiment flag** — drives an A/B test; removed when the experiment concludes.
+- **Permission / entitlement** — long-lived, gates by plan/tenant. This is config, not a
+  feature flag — treat it as such.
+
+Mixing these is how you end up with 200 flags nobody understands. Name and document which
+kind each one is.
+
+## Safe rollout
+
+- **Default off.** A new flag's default is the old behavior. Shipping the code does nothing
+  until you deliberately turn it on.
+- **Ramp progressively:** internal → 1% → canary cohort → 10% → 50% → 100%, watching the
+  error rate and key metrics at each step. Don't jump to 100%.
+- **Make it killable instantly** — flipping off must not require a deploy, and off must be a
+  safe state at any ramp percentage.
+- **Both paths must work at every step.** While a flag is live, old and new code paths both
+  run in production. Test both; don't let the off-path rot.
+
+## The cleanup discipline (where teams fail)
+
+- A release flag is **temporary**. When it's at 100% and stable, delete the flag *and the
+  dead branch* — the code, the config, the tests for the old path. A flag left in forever is
+  a permanent `if` nobody dares remove.
+- Track flag age. A release flag older than its feature is a smell. Put an expiry/owner on
+  it; review stale flags regularly.
+- Avoid **flag dependencies** (flag B only sane when flag A is on) — they multiply states
+  combinatorially and make reasoning impossible.
+
+## Gotchas
+
+- **State explosion:** N flags = up to 2^N code paths. Keep the live set small.
+- **Consistency:** a user flipping mid-session between on/off paths can hit inconsistent
+  state — evaluate the flag once per request/session, not per call.
+- **Don't gate data migrations on a release flag** the way you'd gate UI — a half-migrated
+  schema behind a flag is a different, riskier problem (see `safe-database-migrations`).


### PR DESCRIPTION
New, distinct, validated capabilities (no overlap with existing components):
- **Agents:** data-engineer, sre
- **Skills:** feature-flags, caching-strategies, concurrency-and-parallelism
- **Commands:** /changelog, /scaffold

Forge → 1.1.0. validate ✅ · 241 eval checks ✅ · 54 hook tests ✅ · markdownlint 0.