### PR TITLE
fix(ci): harden source trust boundary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Forge — enterprise-grade agents, orchestration, stacked delivery, catalogs, commands, and hooks for software engineering.",
-    "version": "3.0.0"
+    "version": "3.0.1"
   },
   "plugins": [
     {
       "name": "forge",
       "source": "./plugins/forge",
       "description": "Specialists, orchestration, task ledgers, solve loops, GitHub-native stacked delivery, catalogs, commands, and safety hooks.",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "category": "developer-tooling",
       "keywords": ["agents", "skills", "orchestration", "task-ledger", "stacked-prs", "github", "hooks", "code-review", "testing", "security"]
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       id-token: write
       security-events: write
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,8 +18,8 @@ jobs:
     name: Validate toolkit structure
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.x"
       - name: Validate frontmatter, JSON, and hook scripts
@@ -26,8 +29,8 @@ jobs:
     name: Markdown lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: DavidAnson/markdownlint-cli2-action@v23
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: DavidAnson/markdownlint-cli2-action@29e1992fd532969762382607bd9acb1a05aa4dc8 # v24
         with:
           globs: "**/*.md"
           config: .markdownlint.yaml
@@ -36,8 +39,8 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: ludeeus/action-shellcheck@master
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master
         with:
           scandir: .
           format: gcc
@@ -47,8 +50,8 @@ jobs:
     name: Hook tests (pytest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.x"
       - name: Install pytest
@@ -60,8 +63,8 @@ jobs:
     name: Prompt-quality evals (static)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.x"
       - name: Run static prompt-quality eval
@@ -71,14 +74,14 @@ jobs:
     name: Hook scripts (ruff + compile)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.x"
       - name: Compile hook, skill, eval, and test scripts
         run: python -m py_compile plugins/forge/hooks/scripts/*.py plugins/forge/skills/*/scripts/*.py evals/run.py tests/*.py
       - name: Lint with ruff
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@146cd51f235777a9bc491eead18e0d5a4b05406a # v3
         with:
           args: check plugins/forge/hooks/scripts plugins/forge/skills/stacked-changes/scripts scripts/generate_catalog.py evals tests
 
@@ -86,7 +89,7 @@ jobs:
     name: Plugin manifest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Validate plugin + marketplace JSON
         run: |
           jq empty plugins/forge/.claude-plugin/plugin.json && echo "plugin.json OK"
@@ -97,3 +100,54 @@ jobs:
             && echo "plugin.json has required name field"
           jq -e '.name and .owner and .plugins' .claude-plugin/marketplace.json > /dev/null \
             && echo "marketplace.json has required fields"
+
+  host-validation:
+    name: Host and Agent Skills validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+      - name: Validate Agent Skills format
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' skill; do
+            npx --yes skills-ref@0.1.5 validate "$skill"
+          done < <(find plugins/forge/skills -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+      - name: Install host CLIs
+        run: npm install --global @anthropic-ai/claude-code@2.1.181 @openai/codex@0.146.0
+      - name: Validate Claude plugin strictly
+        run: claude plugin validate --strict plugins/forge
+      - name: Smoke-test Codex marketplace resolution
+        env:
+          CODEX_MARKETPLACE_SOURCE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          codex plugin marketplace add "$CODEX_MARKETPLACE_SOURCE" --json
+          codex plugin list --available --json \
+            | jq -e 'any((.installed // [])[]?; .name == "forge") or any((.available // [])[]?; .name == "forge")'
+
+  scorecard:
+    name: OpenSSF Scorecard
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload Scorecard results
+        uses: github/codeql-action/upload-sarif@0fa1882f994fbd81a47ab0804f93354f5ea40147 # v3.28.17
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [3.0.1] — 2026-07-31
+
+### Added
+
+- **Security and support policy** — documented private vulnerability reporting, support
+  channels, and the boundaries around host permissions and credential management.
+- **Host validation** — CI now validates every Agent Skill directory and both Claude and
+  Codex marketplace surfaces.
+- **OpenSSF Scorecard evidence** — protected CI produces SARIF security results for the
+  repository.
+
+### Changed
+
+- **Workflow trust boundary** — GitHub Actions use reviewed immutable commit SHAs,
+  least-privilege default permissions, and explicit elevated permissions only for
+  Scorecard publication.
+
 ## [3.0.0] — 2026-07-31
 
 ### Added
@@ -198,7 +215,8 @@ plugin under `plugins/forge/`.
 - **Docs** — getting started, usage patterns, architecture, design rationale, and CI &
   headless usage guides.
 
-[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.0.1...HEAD
+[3.0.1]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.0.1
 [3.0.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.0.0
 [2.1.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v2.1.0
 [2.0.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v2.0.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are developed against the latest release on the `main` branch. Older
+releases may not receive a backport unless the issue is critical and the fix is small.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for an undisclosed vulnerability. Use GitHub's private
+security advisory flow for this repository:
+
+<https://github.com/AlisinaDevelo/md-files/security/advisories/new>
+
+Include the affected version or commit, the smallest reproducible example, impact,
+whether credentials or external systems are involved, and any safe mitigation. Redact
+secrets and personal data from reports and reproduction artifacts.
+
+If the private advisory flow is unavailable, open a minimal issue asking for a private
+contact channel without including exploit details.
+
+## Response Expectations
+
+We will acknowledge a report when practical, reproduce it, classify its impact, and
+coordinate disclosure timing with the reporter. Do not test against systems or
+repositories you do not own or have explicit permission to assess.
+
+Forge is a toolkit of Markdown, configuration, hooks, and scripts. A report may affect
+the toolkit itself, an installation path, a host integration, or an example configuration;
+please identify which boundary is involved.
+
+## Security Boundaries
+
+Forge does not replace operating-system isolation, host permissions, GitHub repository
+rules, or credential management. Mutating workflows must still use least-privilege tokens,
+explicit approvals, and protected branches.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,21 @@
+# Support
+
+## Questions and Usage Help
+
+Open a [GitHub discussion](https://github.com/AlisinaDevelo/md-files/discussions) for
+questions about installation, host compatibility, orchestration, skills, or workflows.
+
+## Bugs and Feature Requests
+
+- [Report a bug](https://github.com/AlisinaDevelo/md-files/issues/new?template=bug_report.md)
+- [Propose a component](https://github.com/AlisinaDevelo/md-files/issues/new?template=new_component.md)
+- [Browse the roadmap](https://github.com/AlisinaDevelo/md-files/milestones)
+
+Please include the Forge version, host and host version, operating system, installation
+path, a minimal reproduction, and the relevant command or skill. Remove secrets and
+private repository content before posting.
+
+## Security
+
+Do not report vulnerabilities in a public issue. Follow the process in
+[SECURITY.md](SECURITY.md).

--- a/plugins/forge/.claude-plugin/plugin.json
+++ b/plugins/forge/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "forge",
   "displayName": "Forge",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "An enterprise-grade Claude Code toolkit: specialists, orchestration, task ledgers, solve loops, GitHub-native stacked delivery, commands, and safety hooks.",
   "author": {
     "name": "Alisina Karimi",

--- a/plugins/forge/.codex-plugin/plugin.json
+++ b/plugins/forge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A Codex engineering toolkit with orchestration, task ledgers, solve loops, catalogs, and GitHub-native stacked delivery.",
   "author": {
     "name": "Alisina Karimi",


### PR DESCRIPTION
## Summary

Closes #23.

- Pins every GitHub Action to a reviewed full commit SHA.
- Adds least-privilege workflow permissions.
- Validates all Agent Skills plus Claude and Codex marketplace resolution in CI.
- Adds OpenSSF Scorecard SARIF evidence for trusted workflow events.
- Adds SECURITY.md and SUPPORT.md.
- Aligns manifests and changelog for Forge v3.0.1.

## Verification

- ./scripts/validate.sh
- python3 -m pytest tests/ -q
- markdownlint-cli2 on all Markdown files
- skills-ref validation for all 23 skills
- claude plugin validate --strict plugins/forge
- shellcheck
- actionlint .github/workflows/ci.yml