### PR TITLE
feat(doctor): add read-only repository preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,11 @@ jobs:
         with:
           python-version: "3.x"
       - name: Compile hook, skill, eval, and test scripts
-        run: python -m py_compile plugins/forge/hooks/scripts/*.py plugins/forge/skills/*/scripts/*.py evals/run.py tests/*.py
+        run: python -m py_compile plugins/forge/hooks/scripts/*.py plugins/forge/skills/*/scripts/*.py scripts/*.py evals/run.py tests/*.py
       - name: Lint with ruff
         uses: astral-sh/ruff-action@146cd51f235777a9bc491eead18e0d5a4b05406a # v3
         with:
-          args: check plugins/forge/hooks/scripts plugins/forge/skills/stacked-changes/scripts scripts/generate_catalog.py evals tests
+          args: check plugins/forge/hooks/scripts plugins/forge/skills/stacked-changes/scripts plugins/forge/skills/doctor/scripts scripts/generate_catalog.py scripts/forge-doctor.py evals tests
 
   plugin-manifest:
     name: Plugin manifest

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -8,9 +8,9 @@ Generated from the Forge plugin source. Do not hand-edit component rows; run
 | Kind | Count |
 |------|------:|
 | agents | 20 |
-| skills | 23 |
-| commands | 20 |
-| total | 63 |
+| skills | 24 |
+| commands | 21 |
+| total | 65 |
 
 ## Components
 
@@ -41,6 +41,7 @@ Generated from the Forge plugin source. Do not hand-edit component rows; run
 | `code-review-rubric` | skill | security-sensitive | - | [plugins/forge/skills/code-review-rubric/SKILL.md](plugins/forge/skills/code-review-rubric/SKILL.md) | Use when reviewing code or a pull request to apply a consistent quality bar. Provides a severity-ranked rubric covering correctness, security, tests, readability, and maintainability, plus how to write feedback that gets fixed. See CHECKLIST.md for the full pre-merge checklist. |
 | `concurrency-and-parallelism` | skill | safe | - | [plugins/forge/skills/concurrency-and-parallelism/SKILL.md](plugins/forge/skills/concurrency-and-parallelism/SKILL.md) | Use when writing or reviewing concurrent code — threads, async/await, shared state, locks, and parallel work — or diagnosing a race condition, deadlock, or heisenbug that only appears under load. Covers the patterns that make concurrency correct and the traps that make it intermittently wrong. |
 | `conventional-commits` | skill | safe | - | [plugins/forge/skills/conventional-commits/SKILL.md](plugins/forge/skills/conventional-commits/SKILL.md) | Use when writing git commit messages and structuring commits. Covers the Conventional Commits format, choosing the right type/scope, breaking-change notation, and how to split work into small, atomic, reviewable commits. |
+| `doctor` | skill | safe | - | [plugins/forge/skills/doctor/SKILL.md](plugins/forge/skills/doctor/SKILL.md) | Use before orchestration, stack delivery, or a release when the host and repository need a read-only capability and merge-readiness preflight. Run the Forge Doctor CLI, interpret pass/warn/fail/unknown evidence, and never mutate policy or install tools. |
 | `error-handling` | skill | safe | - | [plugins/forge/skills/error-handling/SKILL.md](plugins/forge/skills/error-handling/SKILL.md) | Use when designing how code handles failure — where to catch, what to propagate, fail-fast vs recover, retries and idempotency, and error types. Covers building robust failure paths without swallowing bugs or over-engineering for impossible cases. |
 | `feature-flags` | skill | safe | - | [plugins/forge/skills/feature-flags/SKILL.md](plugins/forge/skills/feature-flags/SKILL.md) | Use when adding, rolling out, or cleaning up feature flags — gating a change, doing a progressive/canary release, building a kill switch, or removing a stale flag. Covers flag types, safe rollout, and the discipline that keeps flags from becoming permanent tech debt. |
 | `forge-catalog` | skill | safe | - | [plugins/forge/skills/forge-catalog/SKILL.md](plugins/forge/skills/forge-catalog/SKILL.md) | Use when choosing which Forge agent, skill, command, bundle, or workflow should handle a request; when comparing Forge capabilities; when building a focused install surface; or when a user asks "what should I use?" before starting work. Routes to the smallest useful Forge capability instead of loading everything. |
@@ -63,6 +64,7 @@ Generated from the Forge plugin source. Do not hand-edit component rows; run
 | `/commit` | command | critical | sonnet | [plugins/forge/commands/commit.md](plugins/forge/commands/commit.md) | Create a well-formed Conventional Commit for the staged changes |
 | `/debug` | command | safe | sonnet | [plugins/forge/commands/debug.md](plugins/forge/commands/debug.md) | Diagnose a bug or failing test and find the root cause before fixing |
 | `/docs` | command | safe | sonnet | [plugins/forge/commands/docs.md](plugins/forge/commands/docs.md) | Write or update documentation grounded in the actual code |
+| `/doctor` | command | none | - | [plugins/forge/commands/doctor.md](plugins/forge/commands/doctor.md) | Run the read-only Forge capability and merge-readiness preflight |
 | `/explain` | command | safe | sonnet | [plugins/forge/commands/explain.md](plugins/forge/commands/explain.md) | Explain how a file, function, or system works — clearly and accurately |
 | `/forge` | command | safe | sonnet | [plugins/forge/commands/forge.md](plugins/forge/commands/forge.md) | Choose the right Forge agent, skill, command, bundle, or workflow for a goal |
 | `/optimize` | command | safe | sonnet | [plugins/forge/commands/optimize.md](plugins/forge/commands/optimize.md) | Diagnose and fix a performance problem, measuring before and after |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- **Forge Doctor** — a read-only, schema-versioned preflight for host tools, manifest and
+  catalog drift, worktree and stack state, GitHub branch policy, rulesets, signed commits,
+  and Merge Queue coverage. Human and JSON output support online and offline operation.
+
 ## [3.0.1] — 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ files loaded only when needed.
 | [`task-ledger`](plugins/forge/skills/task-ledger/) | Jira/GitHub-issue-like local tasks with status, deps, agent, and model |
 | [`iterate-to-done`](plugins/forge/skills/iterate-to-done/) | Solve-loop discipline for draining a ledger until done or blocked |
 | [`stacked-changes`](plugins/forge/skills/stacked-changes/) | GitHub-native and vendor-neutral stacked PR design, review, restack, recovery, and landing |
+| [`doctor`](plugins/forge/skills/doctor/) | Read-only host, capability, repository-policy, and merge-readiness diagnostics |
 
 ### Commands
 
@@ -196,6 +197,7 @@ User-triggered prompt templates with argument and shell injection.
 | `/solve-loop` | Drain ready ledger tasks with verify-before-done discipline |
 | `/stack` | Plan, inspect, submit, restack, repair, or land dependent pull requests |
 | `/stack-review` | Review every stack layer bottom-up against its immediate parent |
+| `/doctor` | Run the read-only Forge capability and merge-readiness preflight |
 
 ### Hooks
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "total": 63,
+  "total": 65,
   "components": [
     {
       "id": "accessibility-auditor",
@@ -203,6 +203,14 @@
       "risk": "safe"
     },
     {
+      "id": "doctor",
+      "kind": "skill",
+      "path": "plugins/forge/skills/doctor/SKILL.md",
+      "description": "Use before orchestration, stack delivery, or a release when the host and repository need a read-only capability and merge-readiness preflight. Run the Forge Doctor CLI, interpret pass/warn/fail/unknown evidence, and never mutate policy or install tools.",
+      "model": "",
+      "risk": "safe"
+    },
+    {
       "id": "error-handling",
       "kind": "skill",
       "path": "plugins/forge/skills/error-handling/SKILL.md",
@@ -377,6 +385,14 @@
       "description": "Write or update documentation grounded in the actual code",
       "model": "sonnet",
       "risk": "safe"
+    },
+    {
+      "id": "doctor",
+      "kind": "command",
+      "path": "plugins/forge/commands/doctor.md",
+      "description": "Run the read-only Forge capability and merge-readiness preflight",
+      "model": "",
+      "risk": "none"
     },
     {
       "id": "explain",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,6 +69,9 @@ commands, or instruction snippets you want into your own `~/.claude/` or project
 - Run `/stack status` in a large feature — Forge chooses GitHub native or another explicit
   provider, checks every parent edge, and plans reviewable dependent PRs without mutating
   Git or GitHub by default.
+- Run `/doctor` before orchestration or delivery — it reports host tools, manifest and
+  catalog drift, worktree state, stack validity, GitHub branch policy, rulesets, signed
+  commits, and Merge Queue coverage without changing anything.
 - Make an edit that includes a fake AWS key — watch the secret-scanner hook block it.
 - Ask Claude to "debug" a failing test — the root-cause method kicks in.
 
@@ -113,3 +116,5 @@ See [bundles-and-workflows.md](bundles-and-workflows.md) and [CATALOG.md](../CAT
 when choosing a focused Forge route.
 See [stacked-changes.md](stacked-changes.md) for the current GitHub-native stack workflow,
 provider comparison, safety model, and CI guidance.
+See [../plugins/forge/skills/doctor/SKILL.md](../plugins/forge/skills/doctor/SKILL.md) for
+diagnostic statuses, offline behavior, JSON output, and read-only boundaries.

--- a/plugins/forge/commands/doctor.md
+++ b/plugins/forge/commands/doctor.md
@@ -1,0 +1,11 @@
+---
+description: Run the read-only Forge capability and merge-readiness preflight
+argument-hint: "[--json|--offline|--strict]"
+---
+
+Run `python3 scripts/forge-doctor.py` from the repository root with the requested flags.
+Use the `doctor` skill for interpretation.
+
+Report the overall status and the checks that are `warn`, `fail`, or `unknown`. Do not
+repair findings automatically. For JSON consumers, preserve the schema-versioned report
+exactly and explain any skipped network checks.

--- a/plugins/forge/skills/doctor/SKILL.md
+++ b/plugins/forge/skills/doctor/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: doctor
+description: >-
+  Use before orchestration, stack delivery, or a release when the host and repository
+  need a read-only capability and merge-readiness preflight. Run the Forge Doctor CLI,
+  interpret pass/warn/fail/unknown evidence, and never mutate policy or install tools.
+---
+
+# Forge Doctor
+
+Forge Doctor is a read-only preflight for the host and repository. It turns capability
+drift and merge surprises into evidence before a run starts.
+
+## Run it
+
+From the repository root:
+
+```bash
+python3 scripts/forge-doctor.py
+python3 scripts/forge-doctor.py --json
+python3 scripts/forge-doctor.py --offline
+```
+
+Use `--strict` in CI or a release gate when warnings and unknown checks should fail the
+caller. The default mode exits non-zero only for a `fail` check.
+
+## Interpret results
+
+- `pass` means the check found the expected capability or policy.
+- `warn` means work can continue, but a degraded capability or policy gap is visible.
+- `fail` means the run should stop until the reported condition is repaired.
+- `unknown` means the evidence was unavailable, commonly because the run is offline or
+  the GitHub token lacks a read scope.
+
+The JSON report has schema version `1`. It is evidence for orchestration and CI policy,
+not a security certification. It intentionally excludes prompts, credentials, tool
+arguments, and repository file contents beyond concise paths and summaries.
+
+## Boundaries
+
+Doctor does not install tools, write catalogs, change Git state, call mutating GitHub
+endpoints, alter branch protection, or declare a repository secure. Keep local Forge
+stack state in `.forge/stack.json`; Doctor only validates it when present.

--- a/plugins/forge/skills/doctor/scripts/forge-doctor.py
+++ b/plugins/forge/skills/doctor/scripts/forge-doctor.py
@@ -1,0 +1,612 @@
+#!/usr/bin/env python3
+"""Run a read-only Forge host and repository preflight."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+STATUSES = ("pass", "warn", "fail", "unknown")
+PLUGIN = Path("plugins/forge")
+
+
+@dataclass
+class Check:
+    check_id: str
+    status: str
+    summary: str
+    evidence: list[str] = field(default_factory=list)
+    remediation: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "id": self.check_id,
+            "status": self.status,
+            "summary": self.summary,
+            "evidence": self.evidence,
+        }
+        if self.remediation:
+            result["remediation"] = self.remediation
+        return result
+
+
+class Doctor:
+    def __init__(self, repo: Path, offline: bool = False) -> None:
+        self.repo = repo.resolve()
+        self.offline = offline
+        self.checks: list[Check] = []
+        self._remote: tuple[str, str] | None = None
+
+    def add(
+        self,
+        check_id: str,
+        status: str,
+        summary: str,
+        evidence: list[str] | None = None,
+        remediation: str | None = None,
+    ) -> None:
+        if status not in STATUSES:
+            raise ValueError(f"invalid check status: {status}")
+        self.checks.append(
+            Check(check_id, status, summary, evidence or [], remediation)
+        )
+
+    def command(self, args: list[str], timeout: int = 15) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(
+                args,
+                cwd=self.repo,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return subprocess.CompletedProcess(
+                args, 1, "", f"{type(exc).__name__}: {exc}"
+            )
+
+    def run(self) -> dict[str, Any]:
+        self.check_repo()
+        self.check_worktree()
+        self.check_manifests()
+        self.check_catalog()
+        self.check_python_sources()
+        self.check_executables()
+        self.check_plugin_surfaces()
+        self.check_workflow()
+        self.check_stack()
+        self.check_github()
+
+        counts = {status: 0 for status in STATUSES}
+        for check in self.checks:
+            counts[check.status] += 1
+        overall = "fail" if counts["fail"] else "pass"
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "tool": "forge-doctor",
+            "repository": {
+                "name": self.repo.name,
+                "path": str(self.repo),
+            },
+            "mode": "offline" if self.offline else "online",
+            "overall": overall,
+            "summary": counts,
+            "checks": [check.as_dict() for check in self.checks],
+        }
+
+    def check_repo(self) -> None:
+        git_dir = self.repo / ".git"
+        if not git_dir.exists():
+            self.add(
+                "repository.git",
+                "fail",
+                "repository is not a Git worktree",
+                [str(self.repo)],
+                "Run doctor from a Git repository or pass --repo to one.",
+            )
+            return
+        result = self.command(["git", "rev-parse", "--show-toplevel"])
+        if result.returncode:
+            self.add(
+                "repository.git",
+                "fail",
+                "Git worktree could not be inspected",
+                [result.stderr.strip() or "git rev-parse failed"],
+                "Repair the worktree before starting an orchestration run.",
+            )
+        else:
+            self.add("repository.git", "pass", "Git worktree is readable", [result.stdout.strip()])
+
+    def check_worktree(self) -> None:
+        branch_result = self.command(["git", "branch", "--show-current"])
+        branch = branch_result.stdout.strip() or "(detached HEAD)"
+        status_result = self.command(["git", "status", "--porcelain"])
+        markers = []
+        git_dir = self.repo / ".git"
+        if (git_dir / "MERGE_HEAD").exists():
+            markers.append("merge in progress")
+        if (git_dir / "CHERRY_PICK_HEAD").exists():
+            markers.append("cherry-pick in progress")
+        if (git_dir / "rebase-merge").exists() or (git_dir / "rebase-apply").exists():
+            markers.append("rebase in progress")
+        if markers:
+            self.add(
+                "worktree.operation",
+                "fail",
+                "worktree has an unfinished Git operation",
+                markers,
+                "Finish or abort the active Git operation before orchestrating changes.",
+            )
+        elif branch == "(detached HEAD)":
+            self.add(
+                "worktree.branch",
+                "warn",
+                "worktree is detached",
+                [branch],
+                "Switch to an owned branch before creating changes.",
+            )
+        else:
+            self.add("worktree.branch", "pass", "worktree is on a named branch", [branch])
+
+        dirty = [line for line in status_result.stdout.splitlines() if line]
+        if dirty:
+            self.add(
+                "worktree.clean",
+                "warn",
+                "worktree has uncommitted changes",
+                [f"{len(dirty)} changed path(s)"],
+                "Review and preserve existing changes before orchestration mutates anything.",
+            )
+        else:
+            self.add("worktree.clean", "pass", "worktree is clean")
+
+    def check_manifests(self) -> None:
+        paths = [
+            self.repo / PLUGIN / ".claude-plugin" / "plugin.json",
+            self.repo / PLUGIN / ".codex-plugin" / "plugin.json",
+            self.repo / ".claude-plugin" / "marketplace.json",
+        ]
+        try:
+            manifests = [json.loads(path.read_text(encoding="utf-8")) for path in paths]
+            versions = [
+                manifests[0]["version"],
+                manifests[1]["version"],
+                manifests[2]["metadata"]["version"],
+                manifests[2]["plugins"][0]["version"],
+            ]
+        except (OSError, KeyError, IndexError, json.JSONDecodeError, TypeError) as exc:
+            self.add(
+                "forge.manifests",
+                "fail",
+                "Forge manifests are missing or invalid",
+                [str(exc)],
+                "Run the repository validation gate and repair manifest parity.",
+            )
+            return
+        if len(set(versions)) != 1:
+            self.add(
+                "forge.manifests",
+                "fail",
+                "Forge host manifests disagree on version",
+                [", ".join(versions)],
+                "Align Claude, Codex, and marketplace manifest versions.",
+            )
+        else:
+            self.add(
+                "forge.manifests",
+                "pass",
+                "Forge host manifests are valid and version-aligned",
+                [f"version {versions[0]}", "Claude", "Codex", "marketplace"],
+            )
+
+    def check_catalog(self) -> None:
+        script = self.repo / "scripts" / "generate_catalog.py"
+        if not script.exists():
+            self.add(
+                "forge.catalog",
+                "unknown",
+                "catalog generator is unavailable",
+                [str(script)],
+                "Install or restore the Forge repository source before relying on catalog checks.",
+            )
+            return
+        result = self.command([sys.executable, str(script), "--check"])
+        if result.returncode:
+            self.add(
+                "forge.catalog",
+                "fail",
+                "generated catalog is stale",
+                [result.stderr.strip() or result.stdout.strip() or "catalog check failed"],
+                "Run python3 scripts/generate_catalog.py and review the generated diff.",
+            )
+        else:
+            self.add("forge.catalog", "pass", "generated catalog is current")
+
+    def check_python_sources(self) -> None:
+        roots = [
+            self.repo / "scripts",
+            self.repo / PLUGIN / "hooks" / "scripts",
+            self.repo / PLUGIN / "skills",
+        ]
+        files = sorted(
+            path
+            for root in roots
+            if root.exists()
+            for path in root.rglob("*.py")
+            if path.is_file()
+        )
+        failures: list[str] = []
+        for path in files:
+            try:
+                compile(path.read_text(encoding="utf-8"), str(path), "exec")
+            except (OSError, SyntaxError) as exc:
+                failures.append(f"{path.relative_to(self.repo)}: {exc}")
+        if failures:
+            self.add(
+                "forge.sources",
+                "fail",
+                "Forge Python hook and skill sources contain syntax errors",
+                failures,
+                "Repair the reported sources and rerun doctor.",
+            )
+        else:
+            self.add(
+                "forge.sources",
+                "pass",
+                "Forge Python hook and skill sources compile in memory",
+                [f"{len(files)} source file(s) checked"],
+            )
+
+    def check_executables(self) -> None:
+        required = {"git": ["--version"], "python3": ["--version"]}
+        optional = {
+            "gh": ["--version"],
+            "claude": ["--version"],
+            "codex": ["--version"],
+            "jq": ["--version"],
+        }
+        missing_required = [name for name in required if not shutil.which(name)]
+        if missing_required:
+            self.add(
+                "host.required-tools",
+                "fail",
+                "required host tools are missing",
+                missing_required,
+                "Install Git and Python 3 before starting Forge.",
+            )
+        else:
+            self.add("host.required-tools", "pass", "required host tools are available")
+
+        missing_optional = []
+        found_optional = []
+        for name, args in optional.items():
+            executable = shutil.which(name)
+            if not executable:
+                missing_optional.append(name)
+                continue
+            result = self.command([executable, *args], timeout=10)
+            version = (result.stdout or result.stderr).splitlines()[0] if result.returncode == 0 else "unavailable"
+            found_optional.append(f"{name}: {version}")
+        if missing_optional:
+            self.add(
+                "host.optional-tools",
+                "warn",
+                "some optional host tools are unavailable",
+                found_optional + [f"missing: {name}" for name in missing_optional],
+                "Install the missing host or GitHub CLI for the affected integrations.",
+            )
+        else:
+            self.add("host.optional-tools", "pass", "Claude, Codex, GitHub CLI, and jq are available", found_optional)
+
+    def check_workflow(self) -> None:
+        workflows = sorted((self.repo / ".github" / "workflows").glob("*.y*ml"))
+        if not workflows:
+            self.add(
+                "github.merge-group",
+                "unknown",
+                "no GitHub Actions workflows were found",
+                [],
+                "Add or identify the workflow that owns required repository checks.",
+            )
+            return
+        merge_group = [path for path in workflows if "merge_group:" in path.read_text(encoding="utf-8")]
+        if merge_group:
+            self.add(
+                "github.merge-group",
+                "pass",
+                "required workflow coverage includes merge_group",
+                [str(path.relative_to(self.repo)) for path in merge_group],
+            )
+        else:
+            self.add(
+                "github.merge-group",
+                "warn",
+                "workflow coverage does not declare merge_group",
+                [str(path.relative_to(self.repo)) for path in workflows],
+                "Add merge_group checks when the repository uses GitHub Merge Queue.",
+            )
+
+    def check_plugin_surfaces(self) -> None:
+        expected = None
+        manifest = self.repo / PLUGIN / ".codex-plugin" / "plugin.json"
+        try:
+            expected = json.loads(manifest.read_text(encoding="utf-8"))["version"]
+        except (OSError, KeyError, json.JSONDecodeError, TypeError):
+            self.add(
+                "host.plugin-surfaces",
+                "unknown",
+                "installed-host drift could not be compared to a Forge version",
+                [str(manifest)],
+                "Repair the Codex plugin manifest before checking installed host surfaces.",
+            )
+            return
+
+        findings: list[str] = []
+        problems: list[str] = []
+        for host, args in (
+            ("Claude", ["claude", "plugin", "list", "--json"]),
+            ("Codex", ["codex", "plugin", "list", "--json"]),
+        ):
+            if not shutil.which(args[0]):
+                findings.append(f"{host}: CLI unavailable")
+                continue
+            result = self.command(args, timeout=20)
+            if result.returncode:
+                problems.append(f"{host}: plugin list failed")
+                continue
+            try:
+                payload = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                problems.append(f"{host}: plugin list was not valid JSON")
+                continue
+            entries = payload if host == "Claude" else payload.get("installed", [])
+            entry = next(
+                (
+                    item
+                    for item in entries
+                    if item.get("id") == "forge@forge" or item.get("pluginId") == "forge@forge"
+                ),
+                None,
+            )
+            if not entry:
+                problems.append(f"{host}: Forge is not installed")
+                continue
+            installed = entry.get("version", "unknown")
+            findings.append(f"{host}: {installed}")
+            if installed != expected:
+                problems.append(f"{host}: installed {installed}, source {expected}")
+
+        if problems:
+            self.add(
+                "host.plugin-surfaces",
+                "warn",
+                "installed host surfaces have drift or are unavailable",
+                findings + problems,
+                "Install or refresh Forge in each host before relying on its newest capabilities.",
+            )
+        else:
+            self.add(
+                "host.plugin-surfaces",
+                "pass",
+                "installed Claude and Codex Forge surfaces match the source version",
+                [f"version {expected}"] + findings,
+            )
+
+    def check_stack(self) -> None:
+        manifest = self.repo / ".forge" / "stack.json"
+        if not manifest.exists():
+            self.add("forge.stack", "pass", "no Forge stack is active in this checkout")
+            return
+        script = self.repo / PLUGIN / "skills" / "stacked-changes" / "scripts" / "forge-stack.py"
+        if not script.exists():
+            self.add(
+                "forge.stack",
+                "unknown",
+                "stack manifest exists but the stack engine is unavailable",
+                [str(manifest)],
+                "Restore the Forge stack engine before changing stack branches.",
+            )
+            return
+        result = self.command([sys.executable, str(script), "--repo", str(self.repo), "check"])
+        if result.returncode:
+            self.add(
+                "forge.stack",
+                "fail",
+                "active Forge stack is not valid",
+                [result.stderr.strip() or result.stdout.strip() or str(manifest)],
+                "Resolve stack ancestry and manifest errors before delivery.",
+            )
+        else:
+            self.add("forge.stack", "pass", "active Forge stack is valid", [str(manifest)])
+
+    def check_github(self) -> None:
+        if self.offline:
+            for check_id in ("github.auth", "github.branch-policy", "github.rulesets", "github.signatures"):
+                self.add(
+                    check_id,
+                    "unknown",
+                    "network-backed GitHub check skipped in offline mode",
+                    [],
+                    "Rerun without --offline to inspect GitHub repository policy.",
+                )
+            return
+        gh = shutil.which("gh")
+        if not gh:
+            for check_id in ("github.auth", "github.branch-policy", "github.rulesets", "github.signatures"):
+                self.add(
+                    check_id,
+                    "unknown",
+                    "GitHub CLI is unavailable",
+                    [],
+                    "Install and authenticate gh to inspect GitHub policy.",
+                )
+            return
+        remote = self.command(["git", "remote", "get-url", "origin"])
+        parsed = parse_github_remote(remote.stdout.strip()) if remote.returncode == 0 else None
+        if not parsed:
+            for check_id in ("github.auth", "github.branch-policy", "github.rulesets", "github.signatures"):
+                self.add(
+                    check_id,
+                    "unknown",
+                    "origin is not a recognizable GitHub remote",
+                    [remote.stdout.strip() or "origin unavailable"],
+                    "Configure a GitHub origin or use --offline for local-only diagnostics.",
+                )
+            return
+        self._remote = parsed
+        owner, repo = parsed
+        repository = self.github_api(["repos", owner, repo])
+        if repository is None:
+            self.add(
+                "github.auth",
+                "unknown",
+                "GitHub repository metadata could not be read",
+                [f"{owner}/{repo}"],
+                "Authenticate gh and confirm the repository is reachable.",
+            )
+            return
+        self.add("github.auth", "pass", "GitHub API is readable", [f"{owner}/{repo}"])
+        default_branch = repository.get("default_branch", "main")
+        branch_info = self.github_api(["repos", owner, repo, "branches", default_branch])
+        protection = self.github_api(["repos", owner, repo, "branches", default_branch, "protection"])
+        if protection is None:
+            if branch_info and branch_info.get("protected"):
+                self.add(
+                    "github.branch-policy",
+                    "unknown",
+                    "default branch is marked protected but detailed policy is unavailable",
+                    [default_branch],
+                    "Confirm the token can read the branch protection details.",
+                )
+            else:
+                self.add(
+                    "github.branch-policy",
+                    "fail",
+                    "default branch protection could not be read or is absent",
+                    [default_branch],
+                    "Protect the default branch and require the repository validation checks.",
+                )
+        else:
+            required = protection.get("required_status_checks") or {}
+            reviews = protection.get("required_pull_request_reviews")
+            problems = []
+            if not required.get("contexts") and not required.get("checks"):
+                problems.append("no required status checks")
+            if reviews is None:
+                problems.append("pull requests are not required")
+            if (protection.get("allow_force_pushes") or {}).get("enabled"):
+                problems.append("force pushes are allowed")
+            if (protection.get("allow_deletions") or {}).get("enabled"):
+                problems.append("branch deletion is allowed")
+            if not (protection.get("required_conversation_resolution") or {}).get("enabled"):
+                problems.append("conversation resolution is not required")
+            status = "fail" if problems else "pass"
+            self.add(
+                "github.branch-policy",
+                status,
+                "default branch protection is configured" if not problems else "default branch policy has gaps",
+                [default_branch] + problems,
+                "Repair the listed branch protection gaps before a protected landing." if problems else None,
+            )
+
+        rulesets = self.github_api(["repos", owner, repo, "rulesets"])
+        if rulesets is None:
+            self.add(
+                "github.rulesets",
+                "unknown",
+                "repository rulesets could not be inspected",
+                [],
+                "Confirm the token can read repository rulesets.",
+            )
+        else:
+            self.add("github.rulesets", "pass", "repository rulesets are readable", [f"{len(rulesets)} rule set(s)"])
+
+        signatures = self.github_api(["repos", owner, repo, "branches", default_branch, "protection", "required_signatures"])
+        if signatures is None:
+            self.add(
+                "github.signatures",
+                "warn",
+                "required commit-signature policy is unavailable or disabled",
+                [default_branch],
+                "Enable signed commits when repository policy requires cryptographic author identity.",
+            )
+        else:
+            self.add("github.signatures", "pass", "required commit-signature policy is enabled", [default_branch])
+
+    def github_api(self, path: list[str]) -> Any | None:
+        result = self.command(["gh", "api", "/".join(path)], timeout=20)
+        if result.returncode:
+            return None
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return None
+
+
+def parse_github_remote(remote: str) -> tuple[str, str] | None:
+    patterns = (
+        r"^https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$",
+        r"^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$",
+        r"^ssh://git@github\.com/([^/]+)/([^/]+?)(?:\.git)?$",
+    )
+    for pattern in patterns:
+        match = re.match(pattern, remote)
+        if match:
+            return match.group(1), match.group(2)
+    return None
+
+
+def render_human(report: dict[str, Any]) -> str:
+    lines = [
+        f"Forge Doctor (schema v{report['schema_version']})",
+        f"Repository: {report['repository']['name']} [{report['mode']} mode]",
+        "",
+    ]
+    for check in report["checks"]:
+        lines.append(f"[{check['status'].upper():7}] {check['id']}: {check['summary']}")
+        for evidence in check["evidence"]:
+            lines.append(f"          - {evidence}")
+        if check.get("remediation"):
+            lines.append(f"          -> {check['remediation']}")
+    summary = report["summary"]
+    lines += [
+        "",
+        "Summary: "
+        + ", ".join(f"{status}={summary[status]}" for status in STATUSES),
+        f"Overall: {report['overall']}",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run read-only Forge host and repository diagnostics.")
+    parser.add_argument("--repo", type=Path, default=Path.cwd(), help="repository to inspect (default: current directory)")
+    parser.add_argument("--json", action="store_true", help="emit the schema-versioned JSON report")
+    parser.add_argument("--offline", action="store_true", help="skip all network-backed GitHub checks")
+    parser.add_argument("--strict", action="store_true", help="return failure for warnings or unknown checks")
+    args = parser.parse_args(argv)
+
+    report = Doctor(args.repo, offline=args.offline).run()
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_human(report))
+    if report["overall"] == "fail":
+        return 1
+    if args.strict and (report["summary"]["warn"] or report["summary"]["unknown"]):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/forge/skills/doctor/scripts/forge-doctor.py
+++ b/plugins/forge/skills/doctor/scripts/forge-doctor.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-
 SCHEMA_VERSION = 1
 STATUSES = ("pass", "warn", "fail", "unknown")
 PLUGIN = Path("plugins/forge")

--- a/scripts/forge-doctor.py
+++ b/scripts/forge-doctor.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Convenience entry point for the bundled Forge Doctor skill script."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+
+TARGET = (
+    Path(__file__).resolve().parents[1]
+    / "plugins"
+    / "forge"
+    / "skills"
+    / "doctor"
+    / "scripts"
+    / "forge-doctor.py"
+)
+
+
+if __name__ == "__main__":
+    runpy.run_path(str(TARGET), run_name="__main__")

--- a/scripts/forge-doctor.py
+++ b/scripts/forge-doctor.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import runpy
 from pathlib import Path
 
-
 TARGET = (
     Path(__file__).resolve().parents[1]
     / "plugins"

--- a/tests/test_forge_doctor.py
+++ b/tests/test_forge_doctor.py
@@ -1,0 +1,98 @@
+"""Behavioral tests for the read-only Forge Doctor preflight."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "plugins/forge/skills/doctor/scripts/forge-doctor.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("forge_doctor", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("remote", "expected"),
+    [
+        ("https://github.com/AlisinaDevelo/md-files.git", ("AlisinaDevelo", "md-files")),
+        ("git@github.com:AlisinaDevelo/md-files", ("AlisinaDevelo", "md-files")),
+        ("ssh://git@github.com/AlisinaDevelo/md-files.git", ("AlisinaDevelo", "md-files")),
+        ("https://gitlab.com/example/project.git", None),
+    ],
+)
+def test_parse_github_remote(remote, expected):
+    doctor = load_module()
+    assert doctor.parse_github_remote(remote) == expected
+
+
+def test_offline_report_is_schema_versioned_and_deterministic():
+    doctor = load_module()
+    first = doctor.Doctor(REPO, offline=True).run()
+    second = doctor.Doctor(REPO, offline=True).run()
+
+    assert first == second
+    assert first["schema_version"] == 1
+    assert first["mode"] == "offline"
+    assert {check["status"] for check in first["checks"]} >= {"unknown"}
+    network_checks = {"github.auth", "github.branch-policy", "github.rulesets", "github.signatures"}
+    assert all(
+        check["status"] == "unknown"
+        for check in first["checks"]
+        if check["id"] in network_checks
+    )
+
+
+def test_offline_mode_never_calls_github_api(monkeypatch):
+    doctor = load_module()
+    instance = doctor.Doctor(REPO, offline=True)
+
+    def forbidden(_path):
+        raise AssertionError("offline doctor called the GitHub API")
+
+    monkeypatch.setattr(instance, "github_api", forbidden)
+    report = instance.run()
+    assert report["summary"]["unknown"] == 4
+
+
+def test_manifest_drift_is_a_failure(tmp_path):
+    doctor = load_module()
+    (tmp_path / "plugins/forge/.claude-plugin").mkdir(parents=True)
+    (tmp_path / "plugins/forge/.codex-plugin").mkdir(parents=True)
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / "plugins/forge/.claude-plugin/plugin.json").write_text('{"version":"1.0.0"}\n')
+    (tmp_path / "plugins/forge/.codex-plugin/plugin.json").write_text('{"version":"1.1.0"}\n')
+    (tmp_path / ".claude-plugin/marketplace.json").write_text(
+        json.dumps({"metadata": {"version": "1.0.0"}, "plugins": [{"version": "1.0.0"}]})
+    )
+
+    instance = doctor.Doctor(tmp_path, offline=True)
+    instance.check_manifests()
+
+    assert instance.checks[0].status == "fail"
+    assert "disagree" in instance.checks[0].summary
+
+
+def test_cli_json_output_is_parseable():
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(REPO), "--offline", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    report = json.loads(proc.stdout)
+    assert report["tool"] == "forge-doctor"
+    assert report["schema_version"] == 1
+    assert "checks" in report


### PR DESCRIPTION
## Summary

Closes #13.

- Adds the read-only Forge Doctor CLI with human and schema-versioned JSON reports.
- Covers Git/worktree state, manifest parity, generated catalog drift, in-memory source compilation, tools, installed Claude/Codex surfaces, stack validity, Merge Queue coverage, GitHub auth, branch policy, rulesets, and signed-commit policy.
- Supports online, offline, and strict modes with explicit pass/warn/fail/unknown statuses.
- Packages the doctor skill and /doctor command for the Forge plugin.
- Adds fixture/subprocess coverage and updates the catalog, README, getting-started guide, and changelog.

## Verification

- ./scripts/validate.sh
- python3 -m pytest tests/ -q (82 passed)
- markdownlint-cli2 on all Markdown files
- skills-ref validation for all 23 skills
- claude plugin validate --strict plugins/forge
- actionlint .github/workflows/ci.yml
- python3 scripts/forge-doctor.py --json
- git diff --check