### PR TITLE
feat(receipts): add privacy-safe run evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Lint with ruff
         uses: astral-sh/ruff-action@146cd51f235777a9bc491eead18e0d5a4b05406a # v3
         with:
-          args: check plugins/forge/hooks/scripts plugins/forge/skills/stacked-changes/scripts plugins/forge/skills/doctor/scripts scripts/generate_catalog.py scripts/forge-doctor.py evals tests
+          args: check plugins/forge/hooks/scripts plugins/forge/skills/stacked-changes/scripts plugins/forge/skills/doctor/scripts plugins/forge/skills/observability/scripts scripts/generate_catalog.py scripts/forge-doctor.py scripts/forge-receipts.py evals tests
 
   plugin-manifest:
     name: Plugin manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project are documented here. The format is based on
 - **Forge Doctor** — a read-only, schema-versioned preflight for host tools, manifest and
   catalog drift, worktree and stack state, GitHub branch policy, rulesets, signed commits,
   and Merge Queue coverage. Human and JSON output support online and offline operation.
+- **Run receipts** — append-only, privacy-safe JSONL events with idempotency, causality,
+  truncated-record recovery, a versioned schema, and an optional OTLP/HTTP JSON adapter.
 
 ## [3.0.1] — 2026-07-31
 

--- a/data/receipts.schema.json
+++ b/data/receipts.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/AlisinaDevelo/md-files/releases/download/v3.0.1/receipts.schema.json",
+  "title": "Forge Receipt Event",
+  "description": "Append-only, privacy-safe Forge run receipt event.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "event_type",
+    "run_id",
+    "sequence",
+    "occurred_at",
+    "idempotency_key",
+    "attributes"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "event_id": {"type": "string", "minLength": 1},
+    "event_type": {
+      "enum": [
+        "run.started",
+        "run.finished",
+        "task.started",
+        "task.finished",
+        "agent.started",
+        "agent.finished",
+        "model.called",
+        "tool.called",
+        "approval.requested",
+        "approval.granted",
+        "approval.denied",
+        "artifact.recorded",
+        "outcome.recorded"
+      ]
+    },
+    "run_id": {"type": "string", "minLength": 1},
+    "task_id": {"type": "string", "minLength": 1},
+    "agent_id": {"type": "string", "minLength": 1},
+    "sequence": {"type": "integer", "minimum": 1},
+    "occurred_at": {"type": "string", "format": "date-time"},
+    "idempotency_key": {"type": "string", "minLength": 1},
+    "definition_version": {"type": "string", "minLength": 1},
+    "policy_revision": {"type": "string", "minLength": 1},
+    "model_route": {"type": "object"},
+    "trace": {
+      "type": "object",
+      "properties": {
+        "trace_id": {"type": "string", "pattern": "^[0-9a-f]{32}$"},
+        "span_id": {"type": "string", "pattern": "^[0-9a-f]{16}$"},
+        "parent_span_id": {"type": "string", "pattern": "^[0-9a-f]{16}$"},
+        "trace_flags": {"type": "string", "pattern": "^[0-9a-f]{2}$"},
+        "correlation_id": {"type": "string"},
+        "causation_id": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "attributes": {"type": "object"}
+  }
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,3 +118,5 @@ See [stacked-changes.md](stacked-changes.md) for the current GitHub-native stack
 provider comparison, safety model, and CI guidance.
 See [../plugins/forge/skills/doctor/SKILL.md](../plugins/forge/skills/doctor/SKILL.md) for
 diagnostic statuses, offline behavior, JSON output, and read-only boundaries.
+See [receipts.md](receipts.md) for the local evidence contract, privacy boundary, and
+optional OTLP export.

--- a/docs/receipts.md
+++ b/docs/receipts.md
@@ -1,0 +1,60 @@
+# Forge Receipts
+
+Forge receipts are the evidence contract for orchestration. They are append-only JSONL
+events that let a later task sync, policy engine, router, or runtime reconstruct what
+happened without treating telemetry as conversation memory.
+
+## Local storage
+
+The bundled standard-library CLI writes to `.forge/receipts.jsonl` by default:
+
+```bash
+python3 scripts/forge-receipts.py --file .forge/receipts.jsonl append \
+  --event-type run.started --run-id run-2026-08-01 --idempotency-key run-start \
+  --attribute goal=release --attribute status=started
+python3 scripts/forge-receipts.py --file .forge/receipts.jsonl read --json
+python3 scripts/forge-receipts.py --file .forge/receipts.jsonl validate
+```
+
+Every event has a schema version, event and run identity, monotonic sequence, RFC3339
+timestamp, idempotency key, optional task/agent/model/policy fields, causality, and
+structured attributes. The canonical JSON Schema lives at
+[`data/receipts.schema.json`](../data/receipts.schema.json).
+
+Retries with the same idempotency key return the existing event and perform zero writes.
+The store refuses to append after an incomplete final record. `read` can recover the
+valid prefix, while truncation requires the explicit mutating command:
+
+```bash
+python3 scripts/forge-receipts.py --file .forge/receipts.jsonl repair
+```
+
+## Privacy boundary
+
+Prompts, credentials, tokens, tool arguments, raw results, and content are hashed into a
+redaction marker by default. The receipt contains the digest, not the original value.
+Do not put secrets in event identifiers or free-form IDs. Content opt-in is available for
+local, authorized experiments with `--allow-content`; it is never implicit and does not
+override secret-key redaction.
+
+Retention is a storage-owner decision: keep the JSONL file on an encrypted local volume,
+rotate it by run or date, and delete it according to the repository's retention policy.
+Receipts are evidence, not a backup or a prompt-memory store.
+
+## OTLP export
+
+Export uses OTLP/HTTP JSON with no collector dependency for local operation:
+
+```bash
+python3 scripts/forge-receipts.py --file .forge/receipts.jsonl export \
+  --endpoint https://otel.example/v1/traces --header Authorization=Bearer:REDACTED
+```
+
+Use `--dry-run` to inspect the payload without network access. Forge names its own
+`forge.*` attributes and preserves already-approved `gen_ai.*` and `mcp.*` attributes;
+the adapter version is pinned in the exporter as `2025.05` so convention changes are
+explicit. W3C `traceparent` values become OTLP trace and span identifiers, and
+`correlation_id`/`causation_id` remain Forge attributes for task-DAG reconstruction.
+
+The exporter sends spans only. It does not export raw prompts, credentials, tool
+arguments, or results.

--- a/plugins/forge/skills/observability/SKILL.md
+++ b/plugins/forge/skills/observability/SKILL.md
@@ -56,3 +56,10 @@ rate against the error budget.
 For each critical path: emit a metric (rate/error/duration), a span if it crosses a
 service boundary, and structured logs at the decision points and failures. Make the
 failure path as observable as the success path — that's the part you'll need most.
+
+## Forge receipts
+
+For orchestration evidence, use the bundled `scripts/forge-receipts.py` store rather than
+free-form logs. It writes append-only, schema-versioned JSONL with monotonic sequences,
+idempotency keys, causation, W3C trace context, and privacy-safe attributes. Read the
+[receipt guide](../../../docs/receipts.md) before enabling OTLP export.

--- a/plugins/forge/skills/observability/scripts/forge-receipts.py
+++ b/plugins/forge/skills/observability/scripts/forge-receipts.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Store privacy-safe Forge run receipts locally and export them as OTLP JSON."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import re
+import sys
+import uuid
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+from urllib import error as urlerror
+from urllib import request
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows does not expose fcntl.
+    fcntl = None
+
+
+SCHEMA_VERSION = 1
+CONVENTIONS_VERSION = "2025.05"
+EVENT_TYPES = (
+    "run.started",
+    "run.finished",
+    "task.started",
+    "task.finished",
+    "agent.started",
+    "agent.finished",
+    "model.called",
+    "tool.called",
+    "approval.requested",
+    "approval.granted",
+    "approval.denied",
+    "artifact.recorded",
+    "outcome.recorded",
+)
+SENSITIVE_KEYS = (
+    "api_key",
+    "authorization",
+    "credential",
+    "password",
+    "prompt",
+    "raw",
+    "secret",
+    "token",
+    "tool_arg",
+    "tool_argument",
+)
+CONTENT_KEYS = ("arguments", "content", "detail", "message", "output", "result")
+TRACEPARENT_RE = re.compile(r"^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$")
+
+
+class ReceiptError(ValueError):
+    """Raised when a receipt or receipt log violates the contract."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def digest(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return sha256(encoded).hexdigest()
+
+
+def redacted(value: Any) -> dict[str, Any]:
+    return {"redacted": True, "sha256": digest(value)}
+
+
+def sanitize(value: Any, key: str = "", allow_content: bool = False) -> Any:
+    lowered = key.lower().replace("-", "_")
+    if any(token in lowered for token in SENSITIVE_KEYS):
+        return redacted(value)
+    if lowered in CONTENT_KEYS and not allow_content:
+        return redacted(value)
+    if isinstance(value, Mapping):
+        return {
+            str(child_key): sanitize(child_value, str(child_key), allow_content)
+            for child_key, child_value in value.items()
+        }
+    if isinstance(value, list):
+        return [sanitize(item, key, allow_content) for item in value]
+    if isinstance(value, tuple):
+        return [sanitize(item, key, allow_content) for item in value]
+    return value
+
+
+def parse_traceparent(traceparent: str) -> dict[str, str]:
+    match = TRACEPARENT_RE.fullmatch(traceparent.lower())
+    if not match or match.group(1) == "0" * 32 or match.group(2) == "0" * 16:
+        raise ReceiptError("traceparent must be a valid W3C traceparent")
+    return {"trace_id": match.group(1), "parent_span_id": match.group(2), "trace_flags": match.group(3)}
+
+
+def make_event(
+    event_type: str,
+    run_id: str,
+    *,
+    task_id: str | None = None,
+    agent_id: str | None = None,
+    idempotency_key: str | None = None,
+    correlation_id: str | None = None,
+    causation_id: str | None = None,
+    traceparent: str | None = None,
+    definition_version: str | None = None,
+    policy_revision: str | None = None,
+    model_route: Mapping[str, Any] | None = None,
+    attributes: Mapping[str, Any] | None = None,
+    allow_content: bool = False,
+) -> dict[str, Any]:
+    if event_type not in EVENT_TYPES:
+        raise ReceiptError(f"unsupported event type: {event_type}")
+    if not run_id:
+        raise ReceiptError("run_id is required")
+    event_id = str(uuid.uuid4())
+    trace = parse_traceparent(traceparent) if traceparent else {}
+    if trace:
+        trace["span_id"] = sha256(event_id.encode()).hexdigest()[:16]
+    event: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "event_id": event_id,
+        "event_type": event_type,
+        "run_id": run_id,
+        "sequence": 0,
+        "occurred_at": utc_now(),
+        "idempotency_key": idempotency_key or str(uuid.uuid4()),
+        "trace": {
+            **trace,
+            **({"correlation_id": correlation_id} if correlation_id else {}),
+            **({"causation_id": causation_id} if causation_id else {}),
+        },
+        "attributes": sanitize(copy.deepcopy(dict(attributes or {})), allow_content=allow_content),
+    }
+    optional = {
+        "task_id": task_id,
+        "agent_id": agent_id,
+        "definition_version": definition_version,
+        "policy_revision": policy_revision,
+        "model_route": sanitize(copy.deepcopy(dict(model_route or {})), allow_content=allow_content)
+        if model_route
+        else None,
+    }
+    event.update({key: value for key, value in optional.items() if value is not None})
+    return event
+
+
+def validate_event(event: Mapping[str, Any]) -> None:
+    required = (
+        "schema_version",
+        "event_id",
+        "event_type",
+        "run_id",
+        "sequence",
+        "occurred_at",
+        "idempotency_key",
+        "attributes",
+    )
+    missing = [key for key in required if key not in event]
+    if missing:
+        raise ReceiptError("missing required fields: " + ", ".join(missing))
+    if event["schema_version"] != SCHEMA_VERSION:
+        raise ReceiptError(f"unsupported schema_version: {event['schema_version']}")
+    if event["event_type"] not in EVENT_TYPES:
+        raise ReceiptError(f"unsupported event type: {event['event_type']}")
+    if not isinstance(event["sequence"], int) or event["sequence"] < 1:
+        raise ReceiptError("sequence must be a positive integer")
+    for key in ("event_id", "run_id", "idempotency_key", "occurred_at"):
+        if not isinstance(event[key], str) or not event[key]:
+            raise ReceiptError(f"{key} must be a non-empty string")
+    try:
+        datetime.fromisoformat(event["occurred_at"].replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ReceiptError("occurred_at must be RFC3339") from exc
+    if not isinstance(event["attributes"], Mapping):
+        raise ReceiptError("attributes must be an object")
+    if "trace" in event and not isinstance(event["trace"], Mapping):
+        raise ReceiptError("trace must be an object")
+
+
+class ReceiptStore:
+    """Append-only JSONL receipt storage with explicit final-record recovery."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def _parse(self) -> tuple[list[dict[str, Any]], int, bool]:
+        if not self.path.exists():
+            return [], 0, False
+        raw = self.path.read_bytes()
+        events: list[dict[str, Any]] = []
+        valid_bytes = 0
+        truncated = False
+        for index, line in enumerate(raw.splitlines(keepends=True), start=1):
+            if not line.strip():
+                valid_bytes += len(line)
+                continue
+            try:
+                event = json.loads(line.decode("utf-8"))
+                validate_event(event)
+            except (UnicodeDecodeError, json.JSONDecodeError, ReceiptError) as exc:
+                is_final_partial = index == len(raw.splitlines(keepends=True)) and not line.endswith(b"\n")
+                if is_final_partial:
+                    truncated = True
+                    break
+                raise ReceiptError(f"invalid receipt record {index}: {exc}") from exc
+            events.append(event)
+            valid_bytes += len(line)
+        expected = 1
+        for event in events:
+            if event["sequence"] != expected:
+                raise ReceiptError(
+                    f"receipt sequence is not monotonic at {event['event_id']}: expected {expected}, got {event['sequence']}"
+                )
+            expected += 1
+        return events, valid_bytes, truncated
+
+    def read(self) -> tuple[list[dict[str, Any]], bool]:
+        events, _, truncated = self._parse()
+        return events, truncated
+
+    def append(self, event: Mapping[str, Any]) -> dict[str, Any]:
+        candidate = copy.deepcopy(dict(event))
+        existing, _, truncated = self._parse()
+        if truncated:
+            raise ReceiptError("final receipt record is incomplete; run repair before appending")
+        key = candidate.get("idempotency_key")
+        if key:
+            for stored in existing:
+                if stored["idempotency_key"] == key:
+                    return stored
+        candidate["sequence"] = len(existing) + 1
+        validate_event(candidate)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a+", encoding="utf-8") as handle:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            handle.write(json.dumps(candidate, sort_keys=True, separators=(",", ":")) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return candidate
+
+    def repair_truncated_final(self) -> bool:
+        _, valid_bytes, truncated = self._parse()
+        if not truncated:
+            return False
+        with self.path.open("r+b") as handle:
+            handle.truncate(valid_bytes)
+        return True
+
+
+def parse_time(value: str) -> int:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return int(parsed.timestamp() * 1_000_000_000)
+
+
+def otlp_value(value: Any) -> dict[str, Any]:
+    if isinstance(value, bool):
+        return {"boolValue": value}
+    if isinstance(value, int):
+        return {"intValue": str(value)}
+    if isinstance(value, float):
+        return {"doubleValue": value}
+    return {"stringValue": str(value)}
+
+
+def event_attributes(event: Mapping[str, Any]) -> list[dict[str, Any]]:
+    attributes = [
+        ("forge.event_type", event["event_type"]),
+        ("forge.event_id", event["event_id"]),
+        ("forge.run_id", event["run_id"]),
+        ("forge.sequence", event["sequence"]),
+        ("forge.schema_version", event["schema_version"]),
+        ("forge.conventions_version", CONVENTIONS_VERSION),
+    ]
+    trace = event.get("trace", {})
+    if isinstance(trace, Mapping) and trace.get("correlation_id"):
+        attributes.append(("forge.correlation_id", trace["correlation_id"]))
+    for key, value in event.get("attributes", {}).items():
+        if isinstance(value, (str, int, float, bool)):
+            prefix = key if key.startswith(("gen_ai.", "mcp.")) else f"forge.attr.{key}"
+            attributes.append((prefix, value))
+    for key, value in event.get("model_route", {}).items():
+        if isinstance(value, (str, int, float, bool)):
+            prefix = key if key.startswith(("gen_ai.", "mcp.")) else f"forge.route.{key}"
+            attributes.append((prefix, value))
+    return [{"key": key, "value": otlp_value(value)} for key, value in attributes]
+
+
+def event_to_span(event: Mapping[str, Any]) -> dict[str, Any]:
+    trace = event.get("trace", {})
+    trace_id = trace.get("trace_id") if isinstance(trace, Mapping) else None
+    span_id = trace.get("span_id") if isinstance(trace, Mapping) else None
+    trace_id = trace_id or sha256(event["run_id"].encode()).hexdigest()[:32]
+    span_id = span_id or sha256(event["event_id"].encode()).hexdigest()[:16]
+    span: dict[str, Any] = {
+        "traceId": trace_id,
+        "spanId": span_id,
+        "name": event["event_type"],
+        "startTimeUnixNano": str(parse_time(event["occurred_at"])),
+        "attributes": event_attributes(event),
+    }
+    if isinstance(trace, Mapping) and trace.get("parent_span_id"):
+        span["parentSpanId"] = trace["parent_span_id"]
+    return span
+
+
+def otlp_payload(events: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    spans = [event_to_span(event) for event in events]
+    return {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "forge"}},
+                        {"key": "forge.receipt_schema_version", "value": {"intValue": str(SCHEMA_VERSION)}},
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "forge.receipts", "version": str(SCHEMA_VERSION)},
+                        "spans": spans,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def export_otlp(payload: Mapping[str, Any], endpoint: str, headers: Mapping[str, str]) -> int:
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    request_headers = {"Content-Type": "application/json", **headers}
+    req = request.Request(endpoint, data=body, headers=request_headers, method="POST")
+    try:
+        with request.urlopen(req, timeout=20) as response:
+            return response.status
+    except urlerror.URLError as exc:
+        raise ReceiptError(f"OTLP export failed: {exc.reason}") from exc
+
+
+def parse_attributes(values: list[str]) -> dict[str, Any]:
+    attributes: dict[str, Any] = {}
+    for item in values:
+        if "=" not in item:
+            raise ReceiptError(f"attribute must use key=value: {item}")
+        key, value = item.split("=", 1)
+        try:
+            attributes[key] = json.loads(value)
+        except json.JSONDecodeError:
+            attributes[key] = value
+    return attributes
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Store privacy-safe Forge run receipts.")
+    parser.add_argument("--file", type=Path, default=Path(".forge/receipts.jsonl"))
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    append = subparsers.add_parser("append", help="append one receipt event")
+    append.add_argument("--event-type", required=True, choices=EVENT_TYPES)
+    append.add_argument("--run-id", required=True)
+    append.add_argument("--task-id")
+    append.add_argument("--agent-id")
+    append.add_argument("--idempotency-key")
+    append.add_argument("--correlation-id")
+    append.add_argument("--causation-id")
+    append.add_argument("--traceparent")
+    append.add_argument("--definition-version")
+    append.add_argument("--policy-revision")
+    append.add_argument("--model-route", action="append", default=[])
+    append.add_argument("--attribute", action="append", default=[])
+    append.add_argument("--allow-content", action="store_true")
+
+    read = subparsers.add_parser("read", help="read the receipt log")
+    read.add_argument("--json", action="store_true")
+
+    subparsers.add_parser("validate", help="validate the receipt log without changing it")
+    subparsers.add_parser("repair", help="truncate an incomplete final record")
+
+    export = subparsers.add_parser("export", help="export receipts as OTLP/HTTP JSON")
+    export.add_argument("--endpoint", required=True)
+    export.add_argument("--header", action="append", default=[])
+    export.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    store = ReceiptStore(args.file)
+    try:
+        if args.command == "append":
+            event = make_event(
+                args.event_type,
+                args.run_id,
+                task_id=args.task_id,
+                agent_id=args.agent_id,
+                idempotency_key=args.idempotency_key,
+                correlation_id=args.correlation_id,
+                causation_id=args.causation_id,
+                traceparent=args.traceparent,
+                definition_version=args.definition_version,
+                policy_revision=args.policy_revision,
+                model_route=parse_attributes(args.model_route),
+                attributes=parse_attributes(args.attribute),
+                allow_content=args.allow_content,
+            )
+            print(json.dumps(store.append(event), indent=2, sort_keys=True))
+        elif args.command == "read":
+            events, truncated = store.read()
+            if args.json:
+                print(json.dumps({"events": events, "truncated_final_record": truncated}, indent=2, sort_keys=True))
+            else:
+                for event in events:
+                    print(f"{event['sequence']}: {event['event_type']} run={event['run_id']} id={event['event_id']}")
+                if truncated:
+                    print("warning: the final record is incomplete; run repair explicitly to truncate it", file=sys.stderr)
+        elif args.command == "validate":
+            events, truncated = store.read()
+            print(f"valid: {len(events)} event(s); truncated_final_record={str(truncated).lower()}")
+        elif args.command == "repair":
+            repaired = store.repair_truncated_final()
+            print("repaired truncated final record" if repaired else "no repair needed")
+        elif args.command == "export":
+            events, truncated = store.read()
+            payload = otlp_payload(events)
+            if truncated:
+                raise ReceiptError("refusing to export while the final record is incomplete")
+            if args.dry_run:
+                print(json.dumps(payload, indent=2, sort_keys=True))
+            else:
+                headers = parse_headers(args.header)
+                print(f"exported {len(events)} event(s), HTTP {export_otlp(payload, args.endpoint, headers)}")
+    except (OSError, ReceiptError) as exc:
+        print(f"forge-receipts: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def parse_headers(values: list[str]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for item in values:
+        if "=" not in item:
+            raise ReceiptError(f"header must use Name=Value: {item}")
+        key, value = item.split("=", 1)
+        headers[key] = value
+    return headers
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge-receipts.py
+++ b/scripts/forge-receipts.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Convenience entry point for the bundled Forge receipt store."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+TARGET = (
+    Path(__file__).resolve().parents[1]
+    / "plugins"
+    / "forge"
+    / "skills"
+    / "observability"
+    / "scripts"
+    / "forge-receipts.py"
+)
+
+if __name__ == "__main__":
+    runpy.run_path(str(TARGET), run_name="__main__")

--- a/tests/fixtures/receipts/v1.jsonl
+++ b/tests/fixtures/receipts/v1.jsonl
@@ -1,0 +1,2 @@
+{"attributes":{"task_id":"task-1"},"event_id":"event-1","event_type":"run.started","idempotency_key":"idem-1","occurred_at":"2026-08-01T00:00:00.000Z","run_id":"run-1","schema_version":1,"sequence":1,"trace":{"correlation_id":"run-1"}}
+{"attributes":{"status":"ok"},"event_id":"event-2","event_type":"outcome.recorded","idempotency_key":"idem-2","occurred_at":"2026-08-01T00:00:01.000Z","run_id":"run-1","schema_version":1,"sequence":2,"trace":{"causation_id":"event-1","correlation_id":"run-1"}}

--- a/tests/test_forge_receipts.py
+++ b/tests/test_forge_receipts.py
@@ -1,0 +1,135 @@
+"""Behavioral and recovery tests for Forge run receipts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "plugins/forge/skills/observability/scripts/forge-receipts.py"
+FIXTURE = REPO / "tests/fixtures/receipts/v1.jsonl"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("forge_receipts", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def event(module, **kwargs):
+    return module.make_event(
+        kwargs.pop("event_type", "task.started"),
+        kwargs.pop("run_id", "run-1"),
+        attributes=kwargs.pop("attributes", {}),
+        **kwargs,
+    )
+
+
+def test_append_is_monotonic_and_idempotent(tmp_path):
+    module = load_module()
+    store = module.ReceiptStore(tmp_path / "receipts.jsonl")
+    first = event(module, idempotency_key="same-key")
+    stored = store.append(first)
+    retry = store.append(event(module, idempotency_key="same-key"))
+    second = store.append(event(module, idempotency_key="second-key"))
+
+    assert retry == stored
+    assert stored["sequence"] == 1
+    assert second["sequence"] == 2
+    assert len(store.read()[0]) == 2
+
+
+def test_sensitive_values_are_hashed_not_stored(tmp_path):
+    module = load_module()
+    store = module.ReceiptStore(tmp_path / "receipts.jsonl")
+    stored = store.append(
+        event(
+            module,
+            attributes={
+                "prompt": "do not persist this",
+                "api_token": "secret-token",
+                "status": "ok",
+            },
+        )
+    )
+
+    text = (tmp_path / "receipts.jsonl").read_text()
+    assert "do not persist this" not in text
+    assert "secret-token" not in text
+    assert stored["attributes"]["status"] == "ok"
+    assert stored["attributes"]["prompt"]["redacted"] is True
+    assert "sha256" in stored["attributes"]["api_token"]
+
+
+def test_traceparent_and_otlp_preserve_causality():
+    module = load_module()
+    stored = event(
+        module,
+        traceparent="00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+        correlation_id="run-1",
+        causation_id="event-parent",
+        model_route={"gen_ai.system": "openai", "model": "reasoning"},
+        attributes={"status": "ok"},
+    )
+    stored["sequence"] = 1
+    span = module.event_to_span(stored)
+    payload = module.otlp_payload([stored])
+
+    assert span["traceId"] == "0123456789abcdef0123456789abcdef"
+    assert span["spanId"] == stored["trace"]["span_id"]
+    assert span["parentSpanId"] == "0123456789abcdef"
+    assert any(item["key"] == "gen_ai.system" for item in span["attributes"])
+    assert payload["resourceSpans"][0]["scopeSpans"][0]["spans"] == [span]
+
+
+def test_truncated_final_record_is_readable_and_explicitly_repairable(tmp_path):
+    module = load_module()
+    target = tmp_path / "receipts.jsonl"
+    target.write_bytes(FIXTURE.read_bytes() + b'{"schema_version":1,"event_type":"task.started"')
+    store = module.ReceiptStore(target)
+
+    events, truncated = store.read()
+    assert len(events) == 2
+    assert truncated is True
+    with pytest.raises(module.ReceiptError, match="incomplete"):
+        store.append(event(module))
+    assert store.repair_truncated_final() is True
+    assert store.read()[1] is False
+
+
+def test_fixture_is_backward_readable(tmp_path):
+    module = load_module()
+    target = tmp_path / "receipts.jsonl"
+    target.write_bytes(FIXTURE.read_bytes())
+    events, truncated = module.ReceiptStore(target).read()
+
+    assert truncated is False
+    assert [item["sequence"] for item in events] == [1, 2]
+    assert events[1]["trace"]["causation_id"] == "event-1"
+
+
+def test_cli_dry_run_does_not_send_or_write(tmp_path, monkeypatch):
+    module = load_module()
+    store = module.ReceiptStore(tmp_path / "receipts.jsonl")
+    store.append(event(module, attributes={"status": "ok"}))
+    before = (tmp_path / "receipts.jsonl").read_bytes()
+    monkeypatch.setattr(module.request, "urlopen", lambda *_args, **_kwargs: pytest.fail("network call"))
+    payload = module.otlp_payload(store.read()[0])
+
+    assert payload["resourceSpans"]
+    assert (tmp_path / "receipts.jsonl").read_bytes() == before
+
+
+def test_invalid_schema_version_is_rejected():
+    module = load_module()
+    invalid = json.loads(FIXTURE.read_text().splitlines()[0])
+    invalid["schema_version"] = 2
+    with pytest.raises(module.ReceiptError, match="schema_version"):
+        module.validate_event(invalid)


### PR DESCRIPTION
## Summary

Closes #14.

- Adds a versioned Forge receipt schema covering runs, tasks, agents, models, tools, approvals, artifacts, and outcomes.
- Adds append-only local JSONL storage with monotonic sequencing, idempotency keys, causation, and explicit truncated-tail repair.
- Hashes prompts, credentials, tokens, tool arguments, results, and content by default; no raw sensitive values are persisted.
- Adds W3C traceparent propagation and an OTLP/HTTP JSON adapter with Forge, GenAI, and MCP attribute boundaries.
- Adds golden fixtures, migration/recovery tests, docs, and the observability skill guidance.

## Verification

- ./scripts/validate.sh
- python3 -m pytest tests/ -q (89 passed)
- ruff 0.16.1
- markdownlint-cli2 on all Markdown files
- skills-ref validation for all 23 skills
- claude plugin validate --strict plugins/forge
- actionlint .github/workflows/ci.yml
- CLI append/read/export dry-run smoke test