### PR TITLE
feat(tasks): sync Forge ledgers with GitHub Issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Lint with ruff
         uses: astral-sh/ruff-action@146cd51f235777a9bc491eead18e0d5a4b05406a # v3
         with:
-          args: check plugins/forge/hooks/scripts plugins/forge/skills/stacked-changes/scripts plugins/forge/skills/doctor/scripts plugins/forge/skills/observability/scripts scripts/generate_catalog.py scripts/forge-doctor.py scripts/forge-receipts.py evals tests
+          args: check plugins/forge/hooks/scripts plugins/forge/skills/stacked-changes/scripts plugins/forge/skills/doctor/scripts plugins/forge/skills/observability/scripts plugins/forge/skills/task-ledger/scripts scripts/generate_catalog.py scripts/forge-doctor.py scripts/forge-receipts.py scripts/forge-tasks.py evals tests
 
   plugin-manifest:
     name: Plugin manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project are documented here. The format is based on
   and Merge Queue coverage. Human and JSON output support online and offline operation.
 - **Run receipts** — append-only, privacy-safe JSONL events with idempotency, causality,
   truncated-record recovery, a versioned schema, and an optional OTLP/HTTP JSON adapter.
+- **GitHub task-ledger sync** — an explicit local/GitHub authority backend with stable task
+  markers, conflict stops, native sub-issues and blocked-by dependencies, bounded
+  pagination, resumable mutations, deletion/rename safeguards, and receipt-backed evidence.
 
 ## [3.0.1] — 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ proven method, scoped tools, and guardrails. Forge encodes that scaffolding:
   contracts (304 deterministic checks + an opt-in LLM judge); 74 tests cover safety hooks
   and the stack engine. Run them yourself — `just check`.
 - **Auditable & self-validating.** Read every prompt and script. CI validates structure,
-  runs the tests, and scores the evals on every push.
+  runs the tests, and scores the evals on every push. GitHub-backed task ledgers add stable
+  issue identity, native task graphs, conflict stops, and resumable evidence.
 
 ## Install
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,3 +120,5 @@ See [../plugins/forge/skills/doctor/SKILL.md](../plugins/forge/skills/doctor/SKI
 diagnostic statuses, offline behavior, JSON output, and read-only boundaries.
 See [receipts.md](receipts.md) for the local evidence contract, privacy boundary, and
 optional OTLP export.
+See [github-task-ledger.md](github-task-ledger.md) for idempotent GitHub Issues sync,
+native task relationships, conflict handling, and recovery.

--- a/docs/github-task-ledger.md
+++ b/docs/github-task-ledger.md
@@ -1,0 +1,66 @@
+# GitHub Task Ledger
+
+Forge can keep a local Markdown ledger offline or synchronize it with GitHub Issues. Pick
+one authority for a project. Local authority is the default and GitHub authority is an
+explicit import/status mode; the sync engine never performs silent last-write-wins merges.
+
+## Commands
+
+From a repository containing `.forge/tasks/`:
+
+```bash
+python3 scripts/forge-tasks.py --repo AlisinaDevelo/md-files --json plan
+python3 scripts/forge-tasks.py --repo AlisinaDevelo/md-files --json apply --yes
+python3 scripts/forge-tasks.py --repo AlisinaDevelo/md-files --json status
+python3 scripts/forge-tasks.py --repo AlisinaDevelo/md-files --authority github --json import
+python3 scripts/forge-tasks.py --repo AlisinaDevelo/md-files --authority github --json import --write
+```
+
+`plan` is read-only. `apply` is the only command that mutates GitHub and it requires
+`--yes`. Every successful mutation is persisted to `.forge/github-sync.json` and emits a
+privacy-safe idempotent event to `.forge/receipts.jsonl`; use `--receipts PATH` to choose a
+different evidence file.
+
+## Identity and mapping
+
+Each managed issue contains a hidden marker of the form
+`<!-- forge-task:v1 id=... sync=... -->`. The task ID is the stable identity across
+machines, issue renames, imports, retries, and local filename changes. The sync hash is the
+last shared content baseline. Issue titles and bodies carry status, agent, model tier,
+dependencies, parent, release target, goal, acceptance criteria, context, and notes.
+
+Parent tasks use GitHub's native sub-issue relationship. `depends_on` uses GitHub's native
+blocked-by relationship. The graph is never flattened into labels or checklists. A first
+sync creates issues first; run `plan` again to resolve native relationships after GitHub
+has assigned issue IDs.
+
+## Conflicts and recovery
+
+When both local Markdown and the managed issue changed from the same sync baseline, `plan`
+returns a structured `conflict` operation and `apply` refuses to write. Resolve the task
+manually in the authority you choose, update the other side, then plan again. Do not delete
+the marker while resolving; it is the duplicate-prevention key.
+
+The state file records completed operation IDs after each mutation. A retry skips completed
+operations, re-discovers issues created before a process interruption, and checks native
+relationships before adding them again. If a saved issue number no longer exists, the plan
+shows an explicit recreation reason and reuses the same hidden task ID. A renamed repository
+fails before issue scanning so a stale `--repo` cannot write elsewhere.
+
+Pagination is bounded at 100 pages. GitHub API failures preserve the HTTP status and API
+path in machine-readable errors, including insufficient scopes and rate-limit responses.
+The backend requires the repository Issues write permission for apply and the normal `gh`
+authentication for reads. Projects are not required: this backend deliberately does not
+request Projects scopes or mutate Projects, while preserving release/status data in the
+issue body for a future configured Projects adapter.
+
+## Disconnecting safely
+
+To stop synchronization, stop running `apply` and remove or archive `.forge/github-sync.json`
+and `.forge/receipts.jsonl` according to your retention policy. Existing GitHub Issues are
+not deleted or rewritten by disconnecting. To keep local-only operation, omit `--repo` and
+continue using the Markdown ledger and orchestration skills.
+
+The implementation is the standard-library backend at
+`plugins/forge/skills/task-ledger/scripts/forge-tasks.py`; the root script is only a
+convenience wrapper.

--- a/plugins/forge/commands/tasks.md
+++ b/plugins/forge/commands/tasks.md
@@ -20,9 +20,11 @@ Action: $ARGUMENTS
 - **done `<id>`** — only after its acceptance criteria is actually verified; set status
   `done`, note the evidence, and update the board.
 - **block `<id>` `<reason>`** — set status `blocked` with the reason.
-- **sync-gh** — mirror the ledger to GitHub issues with `gh issue create`/`gh issue list`
-  (title → issue title, goal + acceptance criteria → body, status → labels). Keep one backend
-  as the source of truth; don't split state.
+- **sync-gh** — use the bundled backend at `python3 scripts/forge-tasks.py`: run `plan`
+  before `apply --yes`, inspect structured conflicts, and use native sub-issue and
+  blocked-by relationships. Use `--authority github import --write` only when GitHub is
+  the chosen source of truth. See `docs/github-task-ledger.md` for recovery and disconnect
+  behavior.
 
 Keep the ledger honest — reflect the real state of the work, and never commit secrets or
 findings into task files.

--- a/plugins/forge/skills/task-ledger/SKILL.md
+++ b/plugins/forge/skills/task-ledger/SKILL.md
@@ -32,15 +32,23 @@ acceptance criteria is *verified*, not just attempted.
 - **Local markdown (default, zero-dep):** one file per task under `.forge/tasks/`, committed
   with the code. Works in any repo, offline, reviewable in a PR, no auth. This is the default
   and what `/tasks` writes.
-- **GitHub issues (via `gh`):** when the team lives in GitHub, mirror tasks to real issues —
-  `gh issue create`, `gh issue list`, `gh issue close`. The ledger and the issues stay in
-  sync; the acceptance criteria goes in the issue body.
+- **GitHub issues (via `gh`):** when the team lives in GitHub, use the bundled idempotent
+  backend at `scripts/forge-tasks.py` to plan, apply, import, and inspect managed Issues.
+  It uses a hidden stable task marker, sync baselines, native sub-issues, native blocked-by
+  dependencies, resumable state, conflict stops, and privacy-safe receipts. See
+  [GitHub Task Ledger](../../../../docs/github-task-ledger.md) for authority selection and
+  recovery.
 - **Jira / Linear (via MCP):** if a Jira or Linear MCP server is connected, create and
   transition tickets through it. Forge doesn't bundle those integrations (they need
   credentials and an MCP server) — it targets whatever issue MCP you've connected. See
   `mcp/` for how to wire one.
 
 Keep one backend as the source of truth per project; don't split state across two.
+
+For GitHub sync, always run `plan` first and inspect the JSON before `apply --yes`. A
+`conflict` operation is a stop condition, not a suggestion to overwrite either side. The
+backend does not require GitHub Projects and does not silently flatten the task graph into
+labels.
 
 ## Working the ledger
 

--- a/plugins/forge/skills/task-ledger/scripts/forge-tasks.py
+++ b/plugins/forge/skills/task-ledger/scripts/forge-tasks.py
@@ -1,0 +1,717 @@
+#!/usr/bin/env python3
+"""Synchronize Forge Markdown tasks with native GitHub Issues relationships."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+MARKER_RE = re.compile(r"<!-- forge-task:v1 id=(\S+?)(?: sync=([0-9a-f]{64}))? -->")
+STATUS_RE = re.compile(r"^Status:\s*`?([A-Za-z-]+)`?\s*$", re.MULTILINE | re.IGNORECASE)
+ASSIGNED_RE = re.compile(r"^Assigned:\s*([^@\n]+?)(?:\s*@\s*(\S+))?\s*$", re.MULTILINE)
+MODEL_RE = re.compile(r"^Model:\s*`?(\S+?)`?\s*$", re.MULTILINE | re.IGNORECASE)
+DEPENDS_RE = re.compile(r"^Depends on:\s*(.*?)\s*$", re.MULTILINE | re.IGNORECASE)
+PARENT_RE = re.compile(r"^Parent:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE)
+RELEASE_RE = re.compile(r"^Release:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE)
+STATUSES = {"backlog", "ready", "in-progress", "review", "done", "blocked"}
+SCHEMA_VERSION = 1
+
+
+class SyncError(RuntimeError):
+    """Raised for a safe-to-report synchronization failure."""
+
+
+class ApiError(SyncError):
+    def __init__(self, status: int, message: str, path: str) -> None:
+        super().__init__(f"GitHub API {status} for {path}: {message}")
+        self.status = status
+        self.path = path
+
+
+@dataclass
+class Task:
+    task_id: str
+    title: str
+    status: str
+    agent: str
+    model: str
+    depends_on: list[str]
+    parent: str | None
+    release: str | None
+    goal: str
+    acceptance: list[str]
+    context: str
+    notes: str
+    source_path: Path | None = None
+    sync_hash: str | None = None
+
+    def canonical(self) -> dict[str, Any]:
+        return {
+            "id": self.task_id,
+            "title": self.title.strip(),
+            "status": self.status,
+            "agent": self.agent.strip(),
+            "model": self.model.strip(),
+            "depends_on": sorted(self.depends_on),
+            "parent": self.parent,
+            "release": self.release,
+            "goal": self.goal.strip(),
+            "acceptance": [item.strip() for item in self.acceptance],
+            "context": self.context.strip(),
+            "notes": self.notes.strip(),
+        }
+
+    def content_hash(self) -> str:
+        payload = json.dumps(self.canonical(), sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class RemoteIssue:
+    number: int
+    issue_id: int
+    title: str
+    body: str
+    state: str
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RemoteTask:
+    issue: RemoteIssue
+    task: Task
+    sync_hash: str | None
+    sub_issue_ids: set[int] = field(default_factory=set)
+    blocked_by_ids: set[int] = field(default_factory=set)
+
+
+@dataclass
+class Operation:
+    action: str
+    task_id: str | None
+    reason: str
+    issue_number: int | None = None
+    target_task_id: str | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def key(self) -> str:
+        material = {
+            "action": self.action,
+            "task_id": self.task_id,
+            "issue_number": self.issue_number,
+            "target_task_id": self.target_task_id,
+            "payload": self.payload,
+        }
+        return hashlib.sha256(json.dumps(material, sort_keys=True).encode()).hexdigest()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.key(),
+            "action": self.action,
+            "task_id": self.task_id,
+            "target_task_id": self.target_task_id,
+            "issue_number": self.issue_number,
+            "reason": self.reason,
+            "payload": self.payload,
+        }
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, str], str, str | None]:
+    marker = MARKER_RE.search(text)
+    sync_hash = marker.group(2) if marker else None
+    if not text.startswith("---\n"):
+        return {}, text, sync_hash
+    end = text.find("\n---", 4)
+    if end == -1:
+        raise SyncError("task frontmatter is not closed")
+    fields: dict[str, str] = {}
+    for line in text[4:end].splitlines():
+        if ":" in line:
+            key, value = line.split(":", 1)
+            fields[key.strip()] = value.strip().strip('"')
+    return fields, text[end + 4 :], sync_hash
+
+
+def section(body: str, heading: str) -> str:
+    match = re.search(
+        rf"^##\s+{re.escape(heading)}\s*$([\s\S]*?)(?=^##\s+|\Z)",
+        body,
+        re.MULTILINE | re.IGNORECASE,
+    )
+    return match.group(1).strip() if match else ""
+
+
+def acceptance_items(text: str) -> list[str]:
+    return [
+        re.sub(r"^[-*]\s+\[[ xX]\]\s*", "", line).strip()
+        for line in text.splitlines()
+        if re.match(r"^[-*]\s+\[[ xX]\]", line)
+    ]
+
+
+def parse_task_file(path: Path) -> Task:
+    fields, body, sync_hash = parse_frontmatter(path.read_text(encoding="utf-8"))
+    task_id = fields.get("id", path.stem.split("-", 1)[0])
+    status = fields.get("status", "backlog")
+    if status not in STATUSES:
+        raise SyncError(f"{path}: unsupported task status {status}")
+    deps = fields.get("depends_on", "[]").strip("[] ")
+    depends_on = [item.strip() for item in deps.split(",") if item.strip()]
+    goal = section(body, "Goal")
+    acceptance = acceptance_items(section(body, "Acceptance criteria"))
+    return Task(
+        task_id=task_id,
+        title=fields.get("title", path.stem),
+        status=status,
+        agent=fields.get("agent", ""),
+        model=fields.get("model", ""),
+        depends_on=depends_on,
+        parent=fields.get("parent") or None,
+        release=fields.get("release") or None,
+        goal=goal,
+        acceptance=acceptance,
+        context=section(body, "Context"),
+        notes=section(body, "Notes"),
+        source_path=path,
+        sync_hash=sync_hash,
+    )
+
+
+def parse_remote_task(issue: RemoteIssue) -> tuple[Task, str | None] | None:
+    marker = MARKER_RE.search(issue.body)
+    if not marker:
+        return None
+    task_id, sync_hash = marker.group(1), marker.group(2)
+    status_match = STATUS_RE.search(issue.body)
+    status = status_match.group(1).lower() if status_match else ("done" if issue.state == "closed" else "ready")
+    assigned = ASSIGNED_RE.search(issue.body)
+    model_match = MODEL_RE.search(issue.body)
+    deps_match = DEPENDS_RE.search(issue.body)
+    depends_on = []
+    if deps_match and deps_match.group(1).strip() not in {"", "-", "none"}:
+        depends_on = [item.strip().strip("`") for item in deps_match.group(1).split(",")]
+    parent_match = PARENT_RE.search(issue.body)
+    release_match = RELEASE_RE.search(issue.body)
+    parent = parent_match.group(1) if parent_match and parent_match.group(1) != "-" else None
+    release = release_match.group(1) if release_match and release_match.group(1) != "-" else None
+    task = Task(
+        task_id=task_id,
+        title=issue.title,
+        status=status if status in STATUSES else "backlog",
+        agent=assigned.group(1).strip() if assigned else "",
+        model=(assigned.group(2) if assigned and assigned.group(2) else model_match.group(1) if model_match else ""),
+        depends_on=depends_on,
+        parent=parent,
+        release=release,
+        goal=section(issue.body, "Goal"),
+        acceptance=acceptance_items(section(issue.body, "Acceptance criteria")),
+        context=section(issue.body, "Context"),
+        notes=section(issue.body, "Notes"),
+        sync_hash=sync_hash,
+    )
+    return task, sync_hash
+
+
+def render_local(task: Task, sync_hash: str | None = None) -> str:
+    deps = "[" + ", ".join(task.depends_on) + "]"
+    parent = f"parent: {task.parent}\n" if task.parent else ""
+    release = f"release: {task.release}\n" if task.release else ""
+    marker = f"<!-- forge-task:v1 id={task.task_id}"
+    if sync_hash:
+        marker += f" sync={sync_hash}"
+    marker += " -->"
+    acceptance = "\n".join(f"- [ ] {item}" for item in task.acceptance) or "- [ ] Define acceptance criteria"
+    return f"""---
+id: {task.task_id}
+title: {task.title}
+status: {task.status}
+agent: {task.agent}
+model: {task.model}
+depends_on: {deps}
+{parent}{release}---
+{marker}
+
+## Goal
+{task.goal}
+
+## Acceptance criteria
+{acceptance}
+
+## Context
+{task.context}
+
+## Notes
+{task.notes}
+"""
+
+
+def render_remote(task: Task, sync_hash: str) -> str:
+    deps = ", ".join(f"`{item}`" for item in task.depends_on) or "-"
+    assigned = task.agent or "unassigned"
+    model = task.model or "unspecified"
+    parent = task.parent or "-"
+    release = task.release or "-"
+    acceptance = "\n".join(f"- [ ] {item}" for item in task.acceptance) or "- [ ] Define acceptance criteria"
+    return f"""<!-- forge-task:v1 id={task.task_id} sync={sync_hash} -->
+
+Status: `{task.status}`
+Assigned: {assigned} @ {model}
+Depends on: {deps}
+Parent: {parent}
+Release: {release}
+
+## Goal
+{task.goal}
+
+## Acceptance criteria
+{acceptance}
+
+## Context
+{task.context}
+
+## Notes
+{task.notes}
+"""
+
+
+def load_tasks(tasks_dir: Path) -> list[Task]:
+    if not tasks_dir.exists():
+        return []
+    tasks = [parse_task_file(path) for path in sorted(tasks_dir.glob("*.md")) if path.name != "README.md"]
+    ids = [task.task_id for task in tasks]
+    if len(ids) != len(set(ids)):
+        raise SyncError("duplicate Forge task IDs in local ledger")
+    known = set(ids)
+    for task in tasks:
+        unknown = sorted(set(task.depends_on) - known)
+        if task.parent and task.parent not in known:
+            unknown.append(task.parent)
+        if unknown:
+            raise SyncError(f"task {task.task_id} references unknown task(s): {', '.join(unknown)}")
+    return tasks
+
+
+class GitHubClient:
+    """Small gh-backed client with bounded pagination and structured failures."""
+
+    def __init__(self, repository: str, executable: str = "gh") -> None:
+        if not re.fullmatch(r"[^/\s]+/[^/\s]+", repository):
+            raise SyncError("repository must be OWNER/REPO")
+        self.repository = repository
+        self.executable = executable
+
+    def request(self, method: str, path: str, payload: Mapping[str, Any] | None = None) -> Any:
+        command = [self.executable, "api", path, "--method", method, "-H", "Accept: application/vnd.github+json", "-H", "X-GitHub-Api-Version: 2022-11-28"]
+        input_data = None
+        if payload is not None:
+            command.extend(["--input", "-"])
+            input_data = json.dumps(payload)
+        try:
+            result = subprocess.run(command, input=input_data, capture_output=True, text=True, check=False, timeout=30)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise SyncError(f"GitHub CLI unavailable or timed out: {exc}") from exc
+        if result.returncode:
+            status = 0
+            match = re.search(r"HTTP (\d+)", result.stderr)
+            if match:
+                status = int(match.group(1))
+            message = result.stderr.strip() or result.stdout.strip() or "request failed"
+            raise ApiError(status, message, path)
+        try:
+            return json.loads(result.stdout) if result.stdout.strip() else None
+        except json.JSONDecodeError as exc:
+            raise SyncError(f"GitHub returned invalid JSON for {path}") from exc
+
+    def repository_metadata(self) -> dict[str, Any]:
+        data = self.request("GET", f"repos/{self.repository}")
+        if not isinstance(data, dict):
+            raise SyncError("GitHub repository metadata was not an object")
+        return data
+
+    def list_issues(self) -> list[RemoteIssue]:
+        issues: list[RemoteIssue] = []
+        for page in range(1, 101):
+            data = self.request("GET", f"repos/{self.repository}/issues?state=all&per_page=100&page={page}")
+            if not isinstance(data, list):
+                raise SyncError("GitHub issues response was not a list")
+            for item in data:
+                if "pull_request" in item:
+                    continue
+                issues.append(
+                    RemoteIssue(
+                        number=int(item["number"]),
+                        issue_id=int(item["id"]),
+                        title=item.get("title", ""),
+                        body=item.get("body") or "",
+                        state=item.get("state", "open"),
+                        raw=item,
+                    )
+                )
+            if len(data) < 100:
+                return issues
+        raise SyncError("GitHub issue pagination exceeded 100 pages; refusing an unbounded scan")
+
+    def _list_paginated(self, path: str) -> list[dict[str, Any]]:
+        values: list[dict[str, Any]] = []
+        for page in range(1, 101):
+            data = self.request("GET", f"{path}?per_page=100&page={page}")
+            if not isinstance(data, list):
+                raise SyncError(f"GitHub response was not a list for {path}")
+            values.extend(item for item in data if isinstance(item, dict))
+            if len(data) < 100:
+                return values
+        raise SyncError(f"GitHub pagination exceeded 100 pages for {path}; refusing an unbounded scan")
+
+    def list_sub_issues(self, issue_number: int) -> list[dict[str, Any]]:
+        return self._list_paginated(f"repos/{self.repository}/issues/{issue_number}/sub_issues")
+
+    def list_blocked_by(self, issue_number: int) -> list[dict[str, Any]]:
+        return self._list_paginated(f"repos/{self.repository}/issues/{issue_number}/dependencies/blocked_by")
+
+    def create_issue(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        data = self.request("POST", f"repos/{self.repository}/issues", payload)
+        if not isinstance(data, dict) or "number" not in data:
+            raise SyncError("GitHub create issue response was invalid")
+        return data
+
+    def update_issue(self, issue_number: int, payload: Mapping[str, Any]) -> dict[str, Any]:
+        data = self.request("PATCH", f"repos/{self.repository}/issues/{issue_number}", payload)
+        if not isinstance(data, dict):
+            raise SyncError("GitHub update issue response was invalid")
+        return data
+
+    def add_sub_issue(self, parent_number: int, child_issue_id: int) -> None:
+        self.request("POST", f"repos/{self.repository}/issues/{parent_number}/sub_issues", {"sub_issue_id": child_issue_id})
+
+    def add_blocked_by(self, issue_number: int, blocking_issue_id: int) -> None:
+        self.request("POST", f"repos/{self.repository}/issues/{issue_number}/dependencies/blocked_by", {"issue_id": blocking_issue_id})
+
+
+class SyncEngine:
+    def __init__(
+        self,
+        tasks: list[Task],
+        client: Any,
+        state_path: Path,
+        repository: str,
+        receipts_path: Path | None = None,
+    ) -> None:
+        self.tasks = tasks
+        self.client = client
+        self.state_path = state_path
+        self.repository = repository
+        self.receipts_path = receipts_path or state_path.with_name("receipts.jsonl")
+        self.state = load_state(state_path)
+        self.remote: dict[str, RemoteTask] = {}
+        self.remote_by_issue: dict[int, RemoteTask] = {}
+        self.missing_saved_issues: dict[str, int] = {}
+
+    def discover(self) -> None:
+        metadata = self.client.repository_metadata()
+        full_name = metadata.get("full_name")
+        if full_name and full_name.lower() != self.repository.lower():
+            raise SyncError(f"repository was renamed to {full_name}; update --repo and retry")
+        issues = self.client.list_issues()
+        by_id: dict[str, RemoteIssue] = {}
+        for issue in issues:
+            parsed = parse_remote_task(issue)
+            if parsed:
+                task, sync_hash = parsed
+                if task.task_id in by_id:
+                    raise SyncError(f"duplicate remote Forge task marker: {task.task_id}")
+                by_id[task.task_id] = issue
+        for task in self.tasks:
+            issue = by_id.get(task.task_id)
+            if not issue:
+                saved = self.state.get("tasks", {}).get(task.task_id, {})
+                issue_number = saved.get("issue")
+                if issue_number:
+                    self.missing_saved_issues[task.task_id] = int(issue_number)
+                if issue_number:
+                    issue = next((item for item in issues if item.number == issue_number), None)
+            if not issue:
+                continue
+            parsed = parse_remote_task(issue)
+            if not parsed:
+                continue
+            remote_task, sync_hash = parsed
+            sub_ids = {int(item["id"]) for item in self.client.list_sub_issues(issue.number)}
+            blocked_ids = {int(item["id"]) for item in self.client.list_blocked_by(issue.number)}
+            record = RemoteTask(issue, remote_task, sync_hash, sub_ids, blocked_ids)
+            self.remote[task.task_id] = record
+            self.remote_by_issue[issue.number] = record
+
+    def plan(self) -> list[Operation]:
+        operations: list[Operation] = []
+        for task in self.tasks:
+            remote = self.remote.get(task.task_id)
+            current_hash = task.content_hash()
+            if remote is None:
+                previous_issue = self.missing_saved_issues.get(task.task_id)
+                operations.append(
+                    Operation(
+                        "create_issue",
+                        task.task_id,
+                        (
+                            f"previous mapped issue #{previous_issue} is missing; recreate managed issue"
+                            if previous_issue
+                            else "no managed GitHub issue exists"
+                        ),
+                        payload={"title": task.title, "body": render_remote(task, current_hash), "state": issue_state(task)},
+                    )
+                )
+                continue
+            baseline = task.sync_hash or remote.sync_hash
+            local_changed = bool(baseline and current_hash != baseline)
+            remote_changed = bool(baseline and remote.task.content_hash() != baseline)
+            if not baseline and current_hash != remote.task.content_hash():
+                operations.append(Operation("conflict", task.task_id, "both local and remote state lack a shared sync baseline", issue_number=remote.issue.number))
+            elif local_changed and remote_changed and current_hash != remote.task.content_hash():
+                operations.append(Operation("conflict", task.task_id, "local and remote edits diverged from the last shared baseline", issue_number=remote.issue.number))
+            elif current_hash != remote.task.content_hash():
+                action = "update_issue"
+                if issue_state(task) == "closed" and remote.issue.state != "closed":
+                    action = "close_issue"
+                elif issue_state(task) == "open" and remote.issue.state == "closed":
+                    action = "reopen_issue"
+                operations.append(
+                    Operation(
+                        action,
+                        task.task_id,
+                        "local task content changed",
+                        issue_number=remote.issue.number,
+                        payload={"title": task.title, "body": render_remote(task, current_hash), "state": issue_state(task)},
+                    )
+                )
+            elif remote.issue.state != issue_state(task):
+                operations.append(
+                    Operation(
+                        "close_issue" if issue_state(task) == "closed" else "reopen_issue",
+                        task.task_id,
+                        "local task status changed",
+                        issue_number=remote.issue.number,
+                        payload={"state": issue_state(task)},
+                    )
+                )
+
+        issue_ids = {task_id: record.issue.issue_id for task_id, record in self.remote.items()}
+        for task in self.tasks:
+            child = self.remote.get(task.task_id)
+            child_issue_id = issue_ids.get(task.task_id)
+            if task.parent and child and child_issue_id:
+                parent = self.remote.get(task.parent)
+                if parent and child_issue_id not in parent.sub_issue_ids:
+                    operations.append(Operation("add_sub_issue", task.task_id, "parent relationship missing", parent.issue.number, task.parent))
+            for dependency in task.depends_on:
+                dependent = self.remote.get(task.task_id)
+                blocker = self.remote.get(dependency)
+                if dependent and blocker and blocker.issue.issue_id not in dependent.blocked_by_ids:
+                    operations.append(Operation("add_blocked_by", task.task_id, "blocked-by relationship missing", dependent.issue.number, dependency))
+        return operations
+
+    def apply(self, operations: list[Operation], confirm: bool = False) -> list[dict[str, Any]]:
+        if not confirm:
+            raise SyncError("apply requires explicit --yes")
+        if any(operation.action == "conflict" for operation in operations):
+            raise SyncError("conflicts must be resolved before apply")
+        completed = set(self.state.get("completed_operations", []))
+        task_issues = {task_id: data.get("issue") for task_id, data in self.state.get("tasks", {}).items()}
+        results: list[dict[str, Any]] = []
+        for operation in operations:
+            if operation.key() in completed:
+                results.append({"operation": operation.as_dict(), "status": "already-complete"})
+                continue
+            result = self.apply_one(operation, task_issues)
+            completed.add(operation.key())
+            self.state.setdefault("completed_operations", []).append(operation.key())
+            self.state.setdefault("tasks", {}).setdefault(operation.task_id or "", {})["issue"] = task_issues.get(operation.task_id or "")
+            self.state["repository"] = self.repository
+            save_state(self.state_path, self.state)
+            self.record_receipt(operation, result)
+            results.append({"operation": operation.as_dict(), "status": "applied", "result": result})
+        return results
+
+    def record_receipt(self, operation: Operation, result: Mapping[str, Any]) -> None:
+        """Record a redacted, idempotent evidence event for each external mutation."""
+        module_path = Path(__file__).resolve().parents[2] / "observability" / "scripts" / "forge-receipts.py"
+        spec = importlib.util.spec_from_file_location("forge_receipts", module_path)
+        if spec is None or spec.loader is None:
+            raise SyncError("could not load Forge receipt store")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        store = module.ReceiptStore(self.receipts_path)
+        store.append(
+            module.make_event(
+                "tool.called",
+                f"github-sync:{self.repository}",
+                task_id=operation.task_id,
+                idempotency_key=f"forge-tasks:{operation.key()}",
+                attributes={
+                    "sync_action": operation.action,
+                    "sync_status": "applied",
+                    "issue_number": operation.issue_number,
+                    "target_task_id": operation.target_task_id,
+                    "result": dict(result),
+                },
+            )
+        )
+
+    def apply_one(self, operation: Operation, task_issues: dict[str, int | None]) -> dict[str, Any]:
+        if operation.action == "create_issue":
+            marker = MARKER_RE.search(str(operation.payload.get("body", "")))
+            if marker:
+                for issue in self.client.list_issues():
+                    parsed = parse_remote_task(issue)
+                    if parsed and parsed[0].task_id == marker.group(1):
+                        task_issues[operation.task_id or ""] = issue.number
+                        self.state.setdefault("tasks", {}).setdefault(operation.task_id or "", {})["issue"] = issue.number
+                        return {"issue": issue.number, "recovered": True}
+            data = self.client.create_issue(operation.payload)
+            task_issues[operation.task_id or ""] = int(data["number"])
+            self.state.setdefault("tasks", {}).setdefault(operation.task_id or "", {})["issue"] = int(data["number"])
+            return {"issue": int(data["number"])}
+        if operation.action in {"update_issue", "update_state", "close_issue", "reopen_issue"}:
+            data = self.client.update_issue(operation.issue_number, operation.payload)
+            return {"issue": int(data.get("number", operation.issue_number))}
+        if operation.action == "add_sub_issue":
+            parent = task_issues.get(operation.target_task_id or "")
+            child = task_issues.get(operation.task_id or "")
+            if not parent or not child:
+                raise SyncError("sub-issue relationship cannot resolve parent and child issue IDs")
+            child_data = self.client.request("GET", f"repos/{self.repository}/issues/{child}")
+            if any(int(item.get("id", -1)) == int(child_data["id"]) for item in self.client.list_sub_issues(parent)):
+                return {"parent": parent, "child": child, "already_present": True}
+            self.client.add_sub_issue(parent, int(child_data["id"]))
+            return {"parent": parent, "child": child}
+        if operation.action == "add_blocked_by":
+            dependent = task_issues.get(operation.task_id or "")
+            blocker = task_issues.get(operation.target_task_id or "")
+            if not dependent or not blocker:
+                raise SyncError("blocked-by relationship cannot resolve both issue IDs")
+            blocker_data = self.client.request("GET", f"repos/{self.repository}/issues/{blocker}")
+            if any(int(item.get("id", -1)) == int(blocker_data["id"]) for item in self.client.list_blocked_by(dependent)):
+                return {"dependent": dependent, "blocked_by": blocker, "already_present": True}
+            self.client.add_blocked_by(dependent, int(blocker_data["id"]))
+            return {"dependent": dependent, "blocked_by": blocker}
+        raise SyncError(f"unsupported operation: {operation.action}")
+
+
+def issue_state(task: Task) -> str:
+    return "closed" if task.status == "done" else "open"
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"schema_version": SCHEMA_VERSION, "tasks": {}, "completed_operations": []}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SyncError(f"cannot read sync state: {exc}") from exc
+    if data.get("schema_version") != SCHEMA_VERSION:
+        raise SyncError("unsupported sync state schema version")
+    return data
+
+
+def save_state(path: Path, data: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def write_import(tasks_dir: Path, tasks: Iterable[Task]) -> list[str]:
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    existing = {task.task_id: task.source_path for task in load_tasks(tasks_dir)}
+    written: list[str] = []
+    for task in tasks:
+        path = existing.get(task.task_id)
+        if path is None:
+            slug = re.sub(r"[^a-z0-9]+", "-", task.title.lower()).strip("-") or "task"
+            path = tasks_dir / f"{task.task_id}-{slug}.md"
+        path.write_text(render_local(task, task.content_hash()), encoding="utf-8")
+        written.append(str(path))
+    return written
+
+
+def parse_repo(path: Path) -> str:
+    remote = subprocess.run(["git", "remote", "get-url", "origin"], cwd=path, capture_output=True, text=True, check=False)
+    if remote.returncode:
+        raise SyncError("could not infer GitHub repository; pass --repo OWNER/REPO")
+    value = remote.stdout.strip()
+    match = re.search(r"github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?$", value)
+    if not match:
+        raise SyncError("origin is not a GitHub remote; pass --repo OWNER/REPO")
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Synchronize Forge task ledgers with GitHub Issues.")
+    parser.add_argument("--repo", help="GitHub repository OWNER/REPO (default: origin)")
+    parser.add_argument("--tasks-dir", type=Path, default=Path(".forge/tasks"))
+    parser.add_argument("--state", type=Path, default=Path(".forge/github-sync.json"))
+    parser.add_argument("--receipts", type=Path, default=Path(".forge/receipts.jsonl"))
+    parser.add_argument("--json", action="store_true", help="emit machine-readable output")
+    parser.add_argument("--authority", choices=("local", "github"), default="local")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("plan", help="show proposed operations without writing")
+    apply = subparsers.add_parser("apply", help="apply the local-authority plan")
+    apply.add_argument("--yes", action="store_true", help="confirm external writes")
+    import_parser = subparsers.add_parser("import", help="import managed GitHub tasks into local Markdown")
+    import_parser.add_argument("--write", action="store_true", help="write local task files")
+    subparsers.add_parser("status", help="show local/remote mapping and drift")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        repository = args.repo or parse_repo(Path.cwd())
+        tasks = load_tasks(args.tasks_dir)
+        client = GitHubClient(repository)
+        engine = SyncEngine(tasks, client, args.state, repository, args.receipts)
+        engine.discover()
+        if args.authority == "github" and args.command not in {"import", "status"}:
+            raise SyncError("github authority supports import and status; local authority is required for apply")
+        if args.command == "import":
+            remote_tasks = [record.task for record in engine.remote.values()]
+            if args.write:
+                result = {"authority": "github", "written": write_import(args.tasks_dir, remote_tasks)}
+            else:
+                result = {"authority": "github", "would_write": [str(task.task_id) for task in remote_tasks]}
+        elif args.command == "status":
+            operations = engine.plan()
+            result = {
+                "authority": args.authority,
+                "local_tasks": len(tasks),
+                "managed_remote_tasks": len(engine.remote),
+                "operations": [operation.as_dict() for operation in operations],
+            }
+        else:
+            operations = engine.plan()
+            result = {"authority": "local", "operations": [operation.as_dict() for operation in operations]}
+            if args.command == "apply":
+                result["results"] = engine.apply(operations, confirm=args.yes)
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print(json.dumps(result, indent=2, sort_keys=True))
+    except (OSError, SyncError, ApiError) as exc:
+        error = {"error": {"code": type(exc).__name__, "message": str(exc)}}
+        print(json.dumps(error, indent=2) if args.json else f"forge-tasks: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/forge/skills/task-ledger/scripts/forge-tasks.py
+++ b/plugins/forge/skills/task-ledger/scripts/forge-tasks.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-
 MARKER_RE = re.compile(r"<!-- forge-task:v1 id=(\S+?)(?: sync=([0-9a-f]{64}))? -->")
 STATUS_RE = re.compile(r"^Status:\s*`?([A-Za-z-]+)`?\s*$", re.MULTILINE | re.IGNORECASE)
 ASSIGNED_RE = re.compile(r"^Assigned:\s*([^@\n]+?)(?:\s*@\s*(\S+))?\s*$", re.MULTILINE)

--- a/scripts/forge-tasks.py
+++ b/scripts/forge-tasks.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Convenience entry point for the Forge GitHub task-ledger backend."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+
+TARGET = Path(__file__).resolve().parents[1] / "plugins/forge/skills/task-ledger/scripts/forge-tasks.py"
+
+
+if __name__ == "__main__":
+    runpy.run_path(str(TARGET), run_name="__main__")

--- a/scripts/forge-tasks.py
+++ b/scripts/forge-tasks.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import runpy
 from pathlib import Path
 
-
 TARGET = Path(__file__).resolve().parents[1] / "plugins/forge/skills/task-ledger/scripts/forge-tasks.py"
 
 

--- a/tests/test_forge_tasks.py
+++ b/tests/test_forge_tasks.py
@@ -1,0 +1,289 @@
+"""Behavioral tests for Forge's GitHub task-ledger backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "plugins/forge/skills/task-ledger/scripts/forge-tasks.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("forge_tasks", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def task(module, task_id="0001", **overrides):
+    values = {
+        "task_id": task_id,
+        "title": f"Task {task_id}",
+        "status": "ready",
+        "agent": "test-engineer",
+        "model": "sonnet",
+        "depends_on": [],
+        "parent": None,
+        "release": "v3.1.0",
+        "goal": "Deliver a verifiable task.",
+        "acceptance": ["The behavior is tested."],
+        "context": "Use the Forge task ledger.",
+        "notes": "",
+    }
+    values.update(overrides)
+    return module.Task(**values)
+
+
+class FakeGitHub:
+    def __init__(self, module, records=None):
+        self.module = module
+        self.records = records or []
+        self.sub_issues = {}
+        self.blocked_by = {}
+        self.created = []
+        self.updated = []
+        self.relationships = []
+
+    def repository_metadata(self):
+        return {"full_name": "owner/repo"}
+
+    def list_issues(self):
+        return self.records
+
+    def list_sub_issues(self, issue_number):
+        return self.sub_issues.get(issue_number, [])
+
+    def list_blocked_by(self, issue_number):
+        return self.blocked_by.get(issue_number, [])
+
+    def create_issue(self, payload):
+        issue = {"number": 100 + len(self.created), "id": 900 + len(self.created)}
+        self.created.append((issue, payload))
+        return issue
+
+    def update_issue(self, issue_number, payload):
+        self.updated.append((issue_number, payload))
+        return {"number": issue_number}
+
+    def request(self, method, path, payload=None):
+        issue_number = int(path.rsplit("/", 1)[-1])
+        return {"id": issue_number + 800}
+
+    def add_sub_issue(self, parent_number, child_issue_id):
+        self.relationships.append(("sub_issue", parent_number, child_issue_id))
+
+    def add_blocked_by(self, issue_number, blocking_issue_id):
+        self.relationships.append(("blocked_by", issue_number, blocking_issue_id))
+
+
+def remote(module, task_value, number=10, sync_hash=None):
+    sync_hash = sync_hash or task_value.content_hash()
+    return module.RemoteIssue(
+        number=number,
+        issue_id=number + 800,
+        title=task_value.title,
+        body=module.render_remote(task_value, sync_hash),
+        state=module.issue_state(task_value),
+    )
+
+
+def engine(module, tmp_path, tasks, client):
+    instance = module.SyncEngine(tasks, client, tmp_path / "github-sync.json", "owner/repo")
+    instance.discover()
+    return instance
+
+
+def test_remote_round_trip_preserves_identity_and_graph_fields():
+    module = load_module()
+    original = task(module, parent="0000", depends_on=["0002"])
+    parsed = module.parse_remote_task(remote(module, original))
+
+    assert parsed is not None
+    recovered, sync_hash = parsed
+    assert recovered.task_id == "0001"
+    assert recovered.parent == "0000"
+    assert recovered.depends_on == ["0002"]
+    assert sync_hash == original.content_hash()
+    assert recovered.content_hash() == original.content_hash()
+
+
+def test_unchanged_state_produces_zero_operations(tmp_path):
+    module = load_module()
+    value = task(module)
+    client = FakeGitHub(module, [remote(module, value)])
+    instance = engine(module, tmp_path, [value], client)
+
+    assert instance.plan() == []
+
+
+def test_local_edit_plans_one_body_update_without_churn(tmp_path):
+    module = load_module()
+    baseline = task(module)
+    changed = task(module, notes="A verified implementation note.", sync_hash=baseline.content_hash())
+    client = FakeGitHub(module, [remote(module, baseline)])
+    instance = engine(module, tmp_path, [changed], client)
+    operations = instance.plan()
+
+    assert [operation.action for operation in operations] == ["update_issue"]
+    assert operations[0].payload["title"] == changed.title
+    assert operations[0].payload["body"].count("forge-task:v1") == 1
+
+
+def test_status_transition_is_explicit_close_operation(tmp_path):
+    module = load_module()
+    value = task(module, status="done")
+    issue = module.RemoteIssue(
+        number=10,
+        issue_id=810,
+        title=value.title,
+        body=module.render_remote(value, value.content_hash()),
+        state="open",
+    )
+    instance = engine(module, tmp_path, [value], FakeGitHub(module, [issue]))
+
+    operations = instance.plan()
+
+    assert [operation.action for operation in operations] == ["close_issue"]
+    assert operations[0].payload == {"state": "closed"}
+
+
+def test_divergent_local_and_remote_edits_become_structured_conflict(tmp_path):
+    module = load_module()
+    baseline = task(module)
+    local = task(module, notes="Local edit.", sync_hash=baseline.content_hash())
+    remote_task = task(module, notes="Remote edit.")
+    client = FakeGitHub(module, [remote(module, remote_task, sync_hash=baseline.content_hash())])
+    instance = engine(module, tmp_path, [local], client)
+    operations = instance.plan()
+
+    assert len(operations) == 1
+    assert operations[0].action == "conflict"
+    assert "diverged" in operations[0].reason
+
+
+def test_native_sub_issue_and_blocked_by_relationships_are_planned(tmp_path):
+    module = load_module()
+    parent = task(module, "0001")
+    child = task(module, "0002", parent="0001", depends_on=["0001"])
+    client = FakeGitHub(module, [remote(module, parent, 10), remote(module, child, 11)])
+    instance = engine(module, tmp_path, [parent, child], client)
+    operations = instance.plan()
+
+    assert {operation.action for operation in operations} == {"add_sub_issue", "add_blocked_by"}
+    assert {operation.target_task_id for operation in operations} == {"0001"}
+
+
+def test_apply_is_resumable_and_requires_confirmation(tmp_path):
+    module = load_module()
+    value = task(module)
+    client = FakeGitHub(module)
+    instance = engine(module, tmp_path, [value], client)
+    operations = instance.plan()
+
+    with pytest.raises(module.SyncError, match="--yes"):
+        instance.apply(operations)
+    first = instance.apply(operations, confirm=True)
+    second = instance.apply(operations, confirm=True)
+
+    assert first[0]["status"] == "applied"
+    assert second[0]["status"] == "already-complete"
+    assert len(client.created) == 1
+    state = json.loads((tmp_path / "github-sync.json").read_text())
+    assert state["tasks"]["0001"]["issue"] == 100
+    receipts = json.loads((tmp_path / "receipts.jsonl").read_text().splitlines()[0])
+    assert receipts["event_type"] == "tool.called"
+    assert receipts["idempotency_key"].startswith("forge-tasks:")
+
+
+def test_import_is_byte_stable_for_same_task(tmp_path):
+    module = load_module()
+    value = task(module, sync_hash=None)
+    tasks_dir = tmp_path / "tasks"
+    paths = module.write_import(tasks_dir, [value])
+    first = Path(paths[0]).read_bytes()
+    parsed = module.load_tasks(tasks_dir)[0]
+    module.write_import(tasks_dir, [parsed])
+
+    assert Path(paths[0]).read_bytes() == first
+
+
+def test_github_issue_pagination_filters_pull_requests(monkeypatch):
+    module = load_module()
+    client = module.GitHubClient("owner/repo")
+    calls = []
+
+    def fake_request(method, path, payload=None):
+        calls.append(path)
+        if path.endswith("page=1"):
+            return [{"id": 1, "number": 1, "title": "issue", "body": "", "state": "open"}] * 100
+        return [{"id": 2, "number": 2, "title": "pr", "body": "", "state": "open", "pull_request": {}}]
+
+    monkeypatch.setattr(client, "request", fake_request)
+    issues = client.list_issues()
+
+    assert len(issues) == 100
+    assert calls[-1].endswith("page=2")
+
+
+def test_github_api_errors_keep_status_and_path():
+    module = load_module()
+    error = module.ApiError(403, "forbidden", "repos/owner/repo/issues")
+    assert error.status == 403
+    assert error.path.endswith("issues")
+
+
+def test_missing_saved_issue_plans_explicit_recovery(tmp_path):
+    module = load_module()
+    state_path = tmp_path / "github-sync.json"
+    state_path.write_text(json.dumps({"schema_version": 1, "repository": "owner/repo", "tasks": {"0001": {"issue": 44}}, "completed_operations": []}))
+    value = task(module)
+    instance = engine(module, tmp_path, [value], FakeGitHub(module))
+
+    operations = instance.plan()
+
+    assert operations[0].action == "create_issue"
+    assert "recreate" in operations[0].reason
+    assert "#44" in operations[0].reason
+
+
+def test_renamed_repository_stops_before_issue_scan(tmp_path):
+    module = load_module()
+    client = FakeGitHub(module)
+    client.repository_metadata = lambda: {"full_name": "owner/new-repo"}
+
+    with pytest.raises(module.SyncError, match="renamed"):
+        engine(module, tmp_path, [task(module)], client)
+
+
+def test_issue_pagination_has_a_hard_limit(monkeypatch):
+    module = load_module()
+    client = module.GitHubClient("owner/repo")
+    monkeypatch.setattr(client, "request", lambda method, path, payload=None: [{"id": 1, "number": 1, "title": "issue", "body": "", "state": "open"}] * 100)
+
+    with pytest.raises(module.SyncError, match="100 pages"):
+        client.list_issues()
+
+
+def test_relationship_retry_checks_native_graph_before_writing(tmp_path):
+    module = load_module()
+    parent = task(module, "0001")
+    child = task(module, "0002", parent="0001")
+    client = FakeGitHub(module, [remote(module, parent, 10), remote(module, child, 11)])
+    client.sub_issues[10] = []
+    client.blocked_by[11] = []
+    instance = engine(module, tmp_path, [parent, child], client)
+    operation = next(item for item in instance.plan() if item.action == "add_sub_issue")
+    client.sub_issues[10] = [{"id": 811}]
+    instance.state["tasks"] = {"0001": {"issue": 10}, "0002": {"issue": 11}}
+
+    result = instance.apply_one(operation, {"0001": 10, "0002": 11})
+
+    assert result["already_present"] is True
+    assert client.relationships == []


### PR DESCRIPTION
## Summary
- add an idempotent Forge task-ledger backend for GitHub Issues
- preserve parent and dependency graphs with native sub-issues and blocked-by relationships
- add conflict stops, bounded pagination, deletion/rename safeguards, resumable writes, and privacy-safe sync receipts
- document authority selection, recovery, disconnect behavior, and CLI usage

## Verification
- `./scripts/validate.sh`
- `python3 -m pytest tests/ -q` (103 passed)
- `python3 evals/run.py` (307/308, 1 existing warning)
- `python3 -m ruff check ...` (clean)
- read-only live smoke: `python3 scripts/forge-tasks.py --repo AlisinaDevelo/md-files --json plan`

Closes #11
