### PR TITLE
chore(release): Forge 3.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,16 +7,16 @@
   },
   "metadata": {
     "description": "Forge — enterprise-grade agents, orchestration, stacked delivery, catalogs, commands, and hooks for software engineering.",
-    "version": "3.0.1"
+    "version": "3.1.0"
   },
   "plugins": [
     {
       "name": "forge",
       "source": "./plugins/forge",
-      "description": "Specialists, orchestration, task ledgers, solve loops, GitHub-native stacked delivery, catalogs, commands, and safety hooks.",
-      "version": "3.0.1",
+      "description": "Specialists, orchestration, task ledgers, solve loops, policy-gated effects, GitHub-native stacked delivery, catalogs, commands, and safety hooks.",
+      "version": "3.1.0",
       "category": "developer-tooling",
-      "keywords": ["agents", "skills", "orchestration", "task-ledger", "stacked-prs", "github", "hooks", "code-review", "testing", "security"]
+      "keywords": ["agents", "skills", "orchestration", "task-ledger", "stacked-prs", "policy", "authorization", "github", "hooks", "code-review", "testing", "security"]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [3.1.0] — 2026-08-03
+
 ### Added
 
 - **Forge Doctor** — a read-only, schema-versioned preflight for host tools, manifest and
@@ -236,7 +238,8 @@ plugin under `plugins/forge/`.
 - **Docs** — getting started, usage patterns, architecture, design rationale, and CI &
   headless usage guides.
 
-[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/AlisinaDevelo/md-files/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.0.1
 [3.0.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.0.0
 [2.1.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v2.1.0

--- a/plugins/forge/.claude-plugin/plugin.json
+++ b/plugins/forge/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "forge",
   "displayName": "Forge",
-  "version": "3.0.1",
-  "description": "An enterprise-grade Claude Code toolkit: specialists, orchestration, task ledgers, solve loops, GitHub-native stacked delivery, commands, and safety hooks.",
+  "version": "3.1.0",
+  "description": "An enterprise-grade Claude Code toolkit: specialists, orchestration, task ledgers, solve loops, policy-gated effects, GitHub-native stacked delivery, commands, and safety hooks.",
   "author": {
     "name": "Alisina Karimi",
     "email": "alisinakarimi.2003@gmail.com",
@@ -24,6 +24,8 @@
     "orchestration",
     "task-ledger",
     "stacked-prs",
+    "policy",
+    "authorization",
     "github",
     "catalog"
   ]

--- a/plugins/forge/.codex-plugin/plugin.json
+++ b/plugins/forge/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "forge",
-  "version": "3.0.1",
-  "description": "A Codex engineering toolkit with orchestration, task ledgers, solve loops, catalogs, and GitHub-native stacked delivery.",
+  "version": "3.1.0",
+  "description": "A Codex engineering toolkit with orchestration, task ledgers, solve loops, policy-gated effects, catalogs, and GitHub-native stacked delivery.",
   "author": {
     "name": "Alisina Karimi",
     "email": "alisinakarimi.2003@gmail.com",
@@ -16,6 +16,8 @@
     "skills",
     "task-ledger",
     "stacked-prs",
+    "policy",
+    "authorization",
     "github",
     "developer-tooling",
     "prompt-engineering",


### PR DESCRIPTION
## Release

Prepare Forge 3.1.0, the first minor release after the 3.0 stacked-delivery line.

Highlights in the release changelog:

- Forge Doctor preflight and run receipts
- GitHub task-ledger sync and native stacked-PR reconciliation
- cross-host conformance scenarios and evidence
- declarative policy plane with profiles, scoped approvals, staged previews, protected resources, pre-effect rechecks, and committed-effect receipts

Version parity is updated across the Claude plugin, Codex plugin, and Claude marketplace manifests.

## Verification

- `143 passed`
- static eval `312/313` passed with the existing Doctor description warning only
- `./scripts/validate.sh` passed
- Ruff 0.16.1, Markdownlint, Claude strict validation, and host checks passed locally

After merge, tag `v3.1.0` and publish the GitHub release.