### PR TITLE
feat(stack): land native GitHub stacks through async Stack Merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- **Native GitHub Stack Merge** — exact-range previews, expected-head protection, scoped
+  policy approval, durable async request UUIDs, timeout-safe resume, Merge Queue observation,
+  `merge_group` correlation, provider-native fallback, and indeterminate partial-landing
+  detection.
+
 ## [3.1.0] — 2026-08-03
 
 ### Added

--- a/docs/github-native-stacks.md
+++ b/docs/github-native-stacks.md
@@ -48,6 +48,37 @@ recognized before another POST. Completed operation IDs persist in
 `.forge/stack-sync.json`, and successful mutations emit idempotent privacy-safe receipts to
 `.forge/receipts.jsonl`.
 
+## Native Stack Merge
+
+Use the separate landing adapter after `plan` and readiness review:
+
+```bash
+python3 scripts/forge-stack-merge.py --repo OWNER/REPO plan --pr 42 --merge-action default
+python3 scripts/forge-stack-merge.py --repo OWNER/REPO \
+  --policy-profile policies/github-mutation.json submit --pr 42 --yes
+python3 scripts/forge-stack-merge.py --repo OWNER/REPO poll --operation-id OPERATION_ID
+```
+
+The plan binds the exact contiguous range from the lowest unmerged PR through the selected
+target, every expected head SHA, the base SHA, merge method, merge action, readiness gates,
+and expected result. Submit re-fetches the stack immediately before the effect and sends the
+target head SHA to GitHub. `pending` UUIDs and `enqueued` queue handoffs persist in
+`.forge/stack-merge.json`; retries poll those records instead of issuing a second submit.
+
+The async result is not the whole queue lifecycle. An `enqueued` result must be followed by
+queue observation and, when available, a correlated `merge_group` `checks_requested` event:
+
+```bash
+python3 scripts/forge-stack-merge.py --repo OWNER/REPO queue-event \
+  --event merge-group.json --operation-id OPERATION_ID
+```
+
+The event must identify the repository and merge-group head SHA. If GitHub reports failure
+but post-state inspection shows any selected PR merged, Forge returns `indeterminate` with
+`stop-and-reconcile`; it never hides a partial landing. A repository without native Stack
+Merge receives a provider-native bottom-up fallback plan. See the [policy plane](policy-plane.md)
+for scoped approvals and staged previews.
+
 ## Divergence and Recovery
 
 The adapter classifies state as `compatible`, `local-only`, `remote-only`, or `conflicting`.
@@ -63,3 +94,9 @@ reconcile again. Never bypass a conflict with a force push or by editing the rec
 The REST adapter uses GitHub's Stacks API for mutations; the optional GraphQL mode reads the
 stack entry connection with bounded cursor pagination. A native 404 is a feature fallback,
 not evidence that the repository or PR is corrupt.
+
+## Primary Sources
+
+- [GitHub Stack Merge API](https://github.github.com/gh-stack/reference/merge-api/)
+- [GitHub Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+- [GitHub `merge_group` webhook](https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group)

--- a/docs/policy-plane.md
+++ b/docs/policy-plane.md
@@ -56,8 +56,11 @@ privacy sanitizer as a second boundary.
 
 `PolicySession` is the adapter protocol. Optional enterprise policy providers can wrap
 the session at the adapter boundary without adding a dependency to Forge core. The
-bundled task-ledger and stacked-changes adapters opt in with `--policy-profile` and
-support `--policy-staged`, `--policy-approval`, and `--policy-approvals`.
+bundled task-ledger, stacked-changes, and native Stack Merge adapters opt in with
+`--policy-profile` and support `--policy-staged`, `--policy-approval`, and
+`--policy-approvals`. Native landing uses the `github_stack_merge` effect and binds the
+complete contiguous range, expected heads, queue mode, and readiness evidence to the
+approval.
 
 ## CLI examples
 

--- a/plugins/forge/commands/stack.md
+++ b/plugins/forge/commands/stack.md
@@ -25,12 +25,16 @@ repository; otherwise use the manifest's explicit provider.
 - For `review`, compare each branch with its immediate parent and review bottom-up.
 - For `land`, verify approvals/checks and merge parent-first. Stop after each merge to
   restack/retarget and revalidate the next PR; respect the repository's merge queue.
-  With native GitHub stacks use `gh stack merge`, not ordinary `gh pr merge`.
+  With native GitHub stacks use `forge-stack-merge.py` for a previewed async Stack Merge,
+  or `gh stack merge` when the provider owns the landing. Never use ordinary `gh pr merge`
+  for a native stack.
 - For `repair`, identify the first divergence across local ancestry, remote refs, PR bases,
   or CI. Preserve work and provide a reversible recovery sequence.
 - For `sync`, inspect with `forge-stack-sync.py` first; import is read-only unless `--write`,
   and native mutations require local authority plus `--yes`. Stop on SHA drift or a native
   preview fallback.
+- For native landing, treat `.forge/stack-merge.json` as durable request state. Resume a
+  pending UUID or enqueued queue handoff; never submit again after a transport timeout.
 
 Never use `--force`, rewrite trunk/shared branches, bypass a rejected lease, or claim a
 stack is healthy without checking each incremental diff and post-command remote state.

--- a/plugins/forge/skills/stacked-changes/REFERENCE.md
+++ b/plugins/forge/skills/stacked-changes/REFERENCE.md
@@ -64,6 +64,27 @@ GitHub evaluates each layer against the stack's ultimate target, so trunk rules,
 and pull-request CI apply to mid-stack PRs. Webhooks expose stack id/number, size, position,
 and ultimate base; the `stacked` pull-request action fires after a PR joins the stack.
 
+### Native Stack Merge and Merge Queue
+
+The async landing adapter is `scripts/forge-stack-merge.py` (also available as
+`python3 scripts/forge-stack-merge.py`). Its state file is `.forge/stack-merge.json` and
+its receipt stream is `.forge/receipts.jsonl`.
+
+| Command | Effect |
+|---------|--------|
+| `plan --pr N` | Preview exact contiguous range, expected heads, readiness gates, policy effect, and expected result |
+| `submit --pr N --yes` | Re-check remote heads, consume optional scoped approval, submit once, and poll |
+| `poll --operation-id ID` | Resume a persisted pending or enqueued request without a new submit |
+| `queue-event --event FILE --operation-id ID` | Correlate a `merge_group` `checks_requested` delivery with the enqueued receipt |
+
+The adapter sends the selected target PR's expected head SHA to GitHub. It verifies every
+selected layer before submission and verifies every selected PR after a terminal result. A
+failed result with any remote merge evidence becomes `indeterminate` and requires manual
+reconciliation; it is never reported as a clean failure. `enqueued` is a handoff state, not
+completion: queue polling and correlated `merge_group` evidence remain part of the run.
+If Stack Merge is unsupported, the adapter returns a provider-native bottom-up plan and
+does not silently fall back to independent ordinary merges.
+
 ### Vanilla Git and GitHub CLI
 
 - PR `base` is the immediate parent branch; PR `head` is the current branch.

--- a/plugins/forge/skills/stacked-changes/SKILL.md
+++ b/plugins/forge/skills/stacked-changes/SKILL.md
@@ -58,6 +58,28 @@ snapshots in the manifest, treats GitHub as an explicit mutation boundary, and f
 the provider engine when the private-preview API returns 404. See
 [GitHub Native Stacks](../../../../docs/github-native-stacks.md).
 
+For an approved native landing, use `scripts/forge-stack-merge.py`. It previews the exact
+contiguous range, expected head SHAs, merge method, queue mode, readiness gates, and policy
+effect before submitting `PUT .../merge-async`. It persists the returned request UUID in
+`.forge/stack-merge.json`, resumes polling after a timeout without a duplicate submit, and
+records `pending`, `enqueued`, `merged`, `failed`, or `indeterminate` outcomes. An
+`indeterminate` result is a stop signal: inspect remote state before doing anything else.
+
+```bash
+python3 scripts/forge-stack-merge.py --repo OWNER/REPO plan --pr 42 --merge-action default
+python3 scripts/forge-stack-merge.py --repo OWNER/REPO submit --pr 42 --yes
+python3 scripts/forge-stack-merge.py --repo OWNER/REPO poll --operation-id OPERATION_ID
+python3 scripts/forge-stack-merge.py --repo OWNER/REPO queue-event --event merge-group.json --operation-id OPERATION_ID
+```
+
+Use `--policy-profile policies/github-mutation.json` for the scoped approval boundary and
+`--policy-staged` to preview without a submit. The adapter fails closed when required
+checks, reviews, unresolved threads, ruleset evidence, or queue policy are unavailable;
+`--allow-unknown-readiness` is an explicit degraded-mode escape hatch for installations
+whose preview API cannot expose those fields. Native Stack Merge 404s produce a documented
+provider-native bottom-up fallback plan instead of pretending an ordinary PR merge is
+atomic.
+
 ## Author loop
 
 1. Design the stack bottom-up and write one-sentence intent plus acceptance criteria for

--- a/plugins/forge/skills/stacked-changes/scripts/forge-stack-merge.py
+++ b/plugins/forge/skills/stacked-changes/scripts/forge-stack-merge.py
@@ -1,0 +1,873 @@
+#!/usr/bin/env python3
+"""Preview, submit, resume, and audit native GitHub Stack Merge requests."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import sys
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SYNC_PATH = Path(__file__).with_name("forge-stack-sync.py")
+SYNC_SPEC = importlib.util.spec_from_file_location("forge_stack_sync_for_merge", SYNC_PATH)
+if SYNC_SPEC is None or SYNC_SPEC.loader is None:  # pragma: no cover - import failure is host-specific.
+    raise RuntimeError("could not load the native stack sync adapter")
+sync = importlib.util.module_from_spec(SYNC_SPEC)
+sys.modules[SYNC_SPEC.name] = sync
+SYNC_SPEC.loader.exec_module(sync)
+
+RemotePullRequest = sync.RemotePullRequest
+RemoteStack = sync.RemoteStack
+ConflictError = sync.ConflictError
+FeatureUnavailable = sync.FeatureUnavailable
+StackSyncError = sync.StackSyncError
+
+SCHEMA_VERSION = 1
+MERGE_STATUSES = ("pending", "enqueued", "merged", "failed", "indeterminate")
+TERMINAL_STATUSES = {"merged", "failed", "indeterminate"}
+UUID_RE = re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b", re.IGNORECASE)
+
+
+class MergeError(StackSyncError):
+    """Raised for safe-to-report native merge failures."""
+
+
+@dataclass(frozen=True)
+class MergePlan:
+    """The exact stack range and remote preconditions bound by one approval."""
+
+    stack_number: int
+    target_pr: int
+    base_ref: str
+    base_sha: str
+    selected_pull_requests: tuple[int, ...]
+    expected_head_shas: tuple[str, ...]
+    merge_method: str
+    merge_action: str
+    readiness: dict[str, Any]
+
+    @property
+    def expected_target_sha(self) -> str:
+        return self.expected_head_shas[-1]
+
+    @property
+    def expected_result(self) -> str:
+        if self.merge_action == "direct_merge":
+            return "merged"
+        if self.merge_action == "merge_queue":
+            return "enqueued-then-merged"
+        return "merged-or-enqueued"
+
+    @property
+    def operation_id(self) -> str:
+        material = {
+            "schema_version": SCHEMA_VERSION,
+            "stack_number": self.stack_number,
+            "target_pr": self.target_pr,
+            "base_ref": self.base_ref,
+            "base_sha": self.base_sha,
+            "selected_pull_requests": self.selected_pull_requests,
+            "expected_head_shas": self.expected_head_shas,
+            "merge_method": self.merge_method,
+            "merge_action": self.merge_action,
+        }
+        return hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+    def request_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "merge_action": self.merge_action,
+            "sha": self.expected_target_sha,
+        }
+        if self.merge_action != "merge_queue":
+            payload["merge_method"] = self.merge_method
+        return payload
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "operation_id": self.operation_id,
+            "stack_number": self.stack_number,
+            "target_pr": self.target_pr,
+            "base_ref": self.base_ref,
+            "base_sha": self.base_sha,
+            "selected_pull_requests": list(self.selected_pull_requests),
+            "expected_head_shas": list(self.expected_head_shas),
+            "merge_method": self.merge_method,
+            "merge_action": self.merge_action,
+            "expected_result": self.expected_result,
+            "request_payload": self.request_payload(),
+            "preview": {
+                "contiguous_range": list(self.selected_pull_requests),
+                "policy_gate": {
+                    "tool": "forge-stack-merge.submit",
+                    "effect": "github_stack_merge",
+                    "approval": "required",
+                },
+                "readiness": self.readiness,
+            },
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> MergePlan:
+        if value.get("schema_version") != SCHEMA_VERSION:
+            raise MergeError("unsupported native merge state schema version")
+        try:
+            return cls(
+                stack_number=int(value["stack_number"]),
+                target_pr=int(value["target_pr"]),
+                base_ref=str(value["base_ref"]),
+                base_sha=str(value.get("base_sha", "")),
+                selected_pull_requests=tuple(int(item) for item in value["selected_pull_requests"]),
+                expected_head_shas=tuple(str(item) for item in value["expected_head_shas"]),
+                merge_method=str(value["merge_method"]),
+                merge_action=str(value["merge_action"]),
+                readiness=dict(value.get("preview", {}).get("readiness", {"status": "unknown"})),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise MergeError(f"invalid persisted native merge plan: {exc}") from exc
+
+
+def _normalize_result(value: Mapping[str, Any]) -> dict[str, Any]:
+    status = str(value.get("status", "")).lower()
+    if status not in {"pending", "enqueued", "merged", "failed"}:
+        raise MergeError(f"GitHub returned unsupported merge status: {status or 'missing'}")
+    details = value.get("details", {})
+    if not isinstance(details, Mapping):
+        details = {"message": str(details)}
+    result = {"status": status, "details": dict(details)}
+    if value.get("recovered"):
+        result["recovered"] = True
+    return result
+
+
+def _uuid_from(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        details = value.get("details")
+        if isinstance(details, Mapping) and details.get("uuid"):
+            return str(details["uuid"])
+        if value.get("uuid"):
+            return str(value["uuid"])
+    match = UUID_RE.search(str(value))
+    return match.group(0) if match else None
+
+
+def _local_pull_requests(manifest: Mapping[str, Any]) -> list[tuple[dict[str, Any], int]]:
+    return [(branch, int(branch["pr"])) for branch in manifest.get("branches", []) if branch.get("pr")]
+
+
+def plan_merge(
+    manifest: Mapping[str, Any],
+    remote: RemoteStack | None,
+    *,
+    target_pr: int,
+    merge_method: str = "merge",
+    merge_action: str = "default",
+    readiness: Mapping[str, Any] | None = None,
+) -> MergePlan:
+    """Build a byte-stable, exact-range merge preview without making remote changes."""
+
+    if remote is None:
+        raise FeatureUnavailable("the target pull request is not in a native GitHub stack")
+    if merge_method not in {"merge", "squash", "rebase"}:
+        raise MergeError("merge method must be merge, squash, or rebase")
+    if merge_action not in {"default", "direct_merge", "merge_queue"}:
+        raise MergeError("merge action must be default, direct_merge, or merge_queue")
+    remote_numbers = [item.number for item in remote.pull_requests]
+    if target_pr not in remote_numbers:
+        raise MergeError(f"PR #{target_pr} is not in native stack #{remote.number}")
+    local = _local_pull_requests(manifest)
+    local_numbers = [number for _, number in local]
+    if local_numbers and local_numbers != remote_numbers:
+        raise ConflictError("local and remote stack ranges differ; reconcile before landing")
+    for branch, number in local:
+        expected_sha = (branch.get("github") or {}).get("head_sha")
+        if expected_sha:
+            actual = next(item for item in remote.pull_requests if item.number == number).head_sha
+            if expected_sha != actual:
+                raise ConflictError(f"PR #{number} head SHA changed since the stack was recorded")
+    expected_base = str((manifest.get("github_stack") or {}).get("base_sha") or "")
+    if expected_base and remote.base_sha and expected_base != remote.base_sha:
+        raise ConflictError("stack base SHA changed since the stack was recorded")
+    target_index = remote_numbers.index(target_pr)
+    prefix = remote.pull_requests[: target_index + 1]
+    for pull_request in prefix:
+        state = pull_request.state.lower()
+        if state == "closed" and not pull_request.merged_at:
+            raise MergeError(f"PR #{pull_request.number} is closed inside the requested contiguous range")
+    selected = tuple(item for item in prefix if item.state.lower() != "merged" and not item.merged_at)
+    if not selected:
+        raise MergeError(f"PR #{target_pr} is already merged")
+    if selected[-1].number != target_pr:
+        raise MergeError(f"PR #{target_pr} is already merged; choose the highest unmerged PR")
+    if any(item.draft for item in selected):
+        draft = next(item.number for item in selected if item.draft)
+        raise MergeError(f"PR #{draft} is a draft and cannot enter a native stack merge")
+    if any(not item.head_sha for item in selected):
+        raise ConflictError("one or more selected PRs has no remote head SHA")
+    return MergePlan(
+        stack_number=remote.number,
+        target_pr=target_pr,
+        base_ref=remote.base_ref or str(manifest.get("trunk") or "main"),
+        base_sha=remote.base_sha,
+        selected_pull_requests=tuple(item.number for item in selected),
+        expected_head_shas=tuple(item.head_sha for item in selected),
+        merge_method=merge_method,
+        merge_action=merge_action,
+        readiness=dict(readiness or {"status": "unknown", "checks": []}),
+    )
+
+
+def fallback_plan(plan: MergePlan, reason: str) -> dict[str, Any]:
+    return {
+        "status": "fallback",
+        "fallback": True,
+        "reason": reason,
+        "provider_plan": {
+            "strategy": "provider-native-bottom-up",
+            "target_pr": plan.target_pr,
+            "contiguous_range": list(plan.selected_pull_requests),
+            "merge_method": plan.merge_method,
+            "steps": [
+                "run the configured provider's read-only landing plan",
+                "verify reviews, required checks, unresolved threads, rulesets, and queue policy",
+                "land from the lowest unmerged PR upward using the provider's protected merge path",
+                "reconcile remote heads and report every landed or failed PR",
+            ],
+        },
+    }
+
+
+def _readiness_failures(readiness: Mapping[str, Any]) -> list[str]:
+    failures: list[str] = []
+    checks = readiness.get("checks", [])
+    if not isinstance(checks, list):
+        return ["preflight checks are not a list"]
+    for check in checks:
+        if not isinstance(check, Mapping):
+            failures.append("preflight returned a malformed check")
+            continue
+        status = str(check.get("status", "unknown")).lower()
+        if status != "pass":
+            failures.append(f"{check.get('name', 'preflight')}: {check.get('message', status)}")
+    if str(readiness.get("status", "unknown")).lower() != "pass":
+        failures.append(str(readiness.get("message", "preflight is incomplete")))
+    return failures
+
+
+def _load_receipts(path: Path):
+    module_path = SYNC_PATH.parents[2] / "observability" / "scripts" / "forge-receipts.py"
+    spec = importlib.util.spec_from_file_location("forge_receipts_for_stack_merge", module_path)
+    if spec is None or spec.loader is None:
+        raise MergeError("could not load Forge receipt store")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.ReceiptStore(path), module
+
+
+def _record_receipt(path: Path, repository: str, operation_id: str, event: str, result: Mapping[str, Any]) -> None:
+    store, module = _load_receipts(path)
+    store.append(
+        module.make_event(
+            "tool.called" if event == "submit" else "outcome.recorded",
+            f"github-stack-merge:{repository}",
+            idempotency_key=f"forge-stack-merge:{operation_id}:{event}:{hashlib.sha256(json.dumps(dict(result), sort_keys=True).encode()).hexdigest()}",
+            attributes={"merge_event": event, "merge_status": result.get("status", "unknown"), "result": dict(result)},
+        )
+    )
+
+
+def _load_state(path: Path, repository: str | None = None) -> dict[str, Any]:
+    if not path.exists():
+        return {"schema_version": SCHEMA_VERSION, "repository": repository or "", "requests": {}}
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MergeError(f"cannot load native merge state {path}: {exc}") from exc
+    if not isinstance(state, dict) or state.get("schema_version") != SCHEMA_VERSION or not isinstance(state.get("requests"), dict):
+        raise MergeError("native merge state is invalid or unsupported")
+    if repository and state.get("repository") and state["repository"] != repository:
+        raise MergeError("native merge state belongs to a different repository")
+    if repository:
+        state["repository"] = repository
+    return state
+
+
+def _save_state(path: Path, state: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path
+    handle: Any
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False) as handle:
+        temporary = Path(handle.name)
+        json.dump(state, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    try:
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _policy_session(profile: Path, approvals: Path, receipts: Path, principal: str | None, workspace: Path | None):
+    module_path = SYNC_PATH.parents[2] / "policy" / "scripts" / "forge-policy.py"
+    spec = importlib.util.spec_from_file_location("forge_policy_for_stack_merge", module_path)
+    if spec is None or spec.loader is None:
+        raise MergeError("could not load Forge policy engine")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    try:
+        return module.PolicySession(
+            profile,
+            approvals_path=approvals,
+            receipts_path=receipts,
+            principal=principal,
+            workspace=workspace or Path.cwd(),
+        ), module.PolicyError
+    except module.PolicyError as exc:
+        raise MergeError(str(exc)) from exc
+
+
+def _authorization(
+    plan: MergePlan,
+    repository: str,
+    *,
+    profile: Path,
+    approvals: Path,
+    receipts: Path,
+    approval_id: str | None,
+    staged: bool,
+    principal: str | None,
+    workspace: Path | None,
+):
+    policy, error_type = _policy_session(profile, approvals, receipts, principal, workspace)
+    action = policy.action(
+        action_id=f"forge-stack-merge:{plan.operation_id}",
+        tool="forge-stack-merge.submit",
+        arguments=plan.as_dict(),
+        repository=repository,
+        branch=plan.base_ref,
+        paths=[],
+        domains=["github.com"],
+        effect="github_stack_merge",
+        risk="critical",
+        fan_out=len(plan.selected_pull_requests),
+    )
+    try:
+        return policy, error_type, policy.authorize(action, approval_id=approval_id, staged=staged)
+    except Exception as exc:
+        if isinstance(exc, error_type):
+            raise MergeError(str(exc)) from exc
+        raise
+
+
+def _verify_observed(plan: MergePlan, observed: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    merged = {int(item) for item in observed.get("merged_prs", [])}
+    selected = set(plan.selected_pull_requests)
+    if selected and selected.issubset(merged):
+        return "merged", {"status": "merged", "observed": dict(observed)}
+    if selected.intersection(merged):
+        return "partial", {"status": "partial", "observed": dict(observed)}
+    return "none", {"status": "not-merged", "observed": dict(observed)}
+
+
+def _terminal_result(client: Any, plan: MergePlan, result: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = _normalize_result(result)
+    observed = client.observe_plan(plan)
+    if not isinstance(observed, Mapping):
+        raise MergeError("post-merge observation was not an object")
+    observation_status, evidence = _verify_observed(plan, observed)
+    if normalized["status"] == "merged" and observation_status != "merged":
+        return {
+            "status": "indeterminate",
+            "action": "stop-and-reconcile",
+            "message": "GitHub reported merged, but post-state verification did not show every selected PR merged",
+            "native_result": normalized,
+            "evidence": evidence,
+            "partial_merge_detected": observation_status == "partial",
+        }
+    if normalized["status"] == "failed" and observation_status == "partial":
+        return {
+            "status": "indeterminate",
+            "action": "stop-and-reconcile",
+            "message": "GitHub reported failure after remote merge evidence appeared; partial landing must be reconciled",
+            "native_result": normalized,
+            "evidence": evidence,
+            "partial_merge_detected": True,
+        }
+    return {**normalized, "evidence": evidence}
+
+
+def _persist_request(state: dict[str, Any], plan: MergePlan, result: Mapping[str, Any], *, request_uuid: str | None = None, timed_out: bool = False) -> dict[str, Any]:
+    existing = state["requests"].get(plan.operation_id, {})
+    record = {
+        **existing,
+        "schema_version": SCHEMA_VERSION,
+        "operation_id": plan.operation_id,
+        "plan": plan.as_dict(),
+        "request_uuid": request_uuid or existing.get("request_uuid"),
+        "status": result.get("status"),
+        "last_result": dict(result),
+        "timed_out": timed_out,
+    }
+    state["requests"][plan.operation_id] = record
+    return record
+
+
+def execute_merge(
+    client: Any,
+    repository: str,
+    plan: MergePlan,
+    state_path: Path,
+    receipts_path: Path,
+    *,
+    yes: bool,
+    authority: str = "local",
+    policy_profile: Path | None = None,
+    policy_approval: str | None = None,
+    policy_staged: bool = False,
+    policy_approvals_path: Path | None = None,
+    policy_principal: str | None = None,
+    workspace: Path | None = None,
+    poll_attempts: int = 10,
+    allow_unknown_readiness: bool = False,
+    allow_submit: bool = True,
+) -> dict[str, Any]:
+    """Submit once, persist the UUID, and resume polling without duplicate writes."""
+
+    if authority != "local":
+        raise MergeError("only local authority may submit native stack merges")
+    if not yes and not policy_staged:
+        raise MergeError("submit requires explicit --yes")
+    if policy_staged and policy_profile is None:
+        raise MergeError("--policy-staged requires --policy-profile")
+    if poll_attempts < 0:
+        raise MergeError("poll attempts cannot be negative")
+    state = _load_state(state_path, repository)
+    existing = state["requests"].get(plan.operation_id)
+    if existing and existing.get("status") in TERMINAL_STATUSES:
+        return dict(existing.get("last_result") or {"status": existing["status"]})
+    if not existing and not allow_submit:
+        raise MergeError("no persisted native merge request for this operation")
+    policy = None
+    authorization = None
+    policy_error_type = None
+    native_result: dict[str, Any]
+    if not existing:
+        try:
+            client.verify_plan(plan)
+            readiness = client.preflight_plan(plan)
+        except FeatureUnavailable:
+            return fallback_plan(plan, "native GitHub Stack Merge is unavailable for this repository")
+        except StackSyncError as exc:
+            raise MergeError(f"native merge preflight failed: {exc}") from exc
+        if not isinstance(readiness, Mapping):
+            raise MergeError("native merge preflight returned an invalid result")
+        plan = MergePlan(**{**plan.__dict__, "readiness": dict(readiness)})
+        failures = _readiness_failures(readiness)
+        if failures and not allow_unknown_readiness:
+            raise MergeError("native merge preflight did not pass: " + "; ".join(failures))
+        if policy_profile is not None:
+            policy, policy_error_type, authorization = _authorization(
+                plan,
+                repository,
+                profile=policy_profile,
+                approvals=policy_approvals_path or state_path.with_name("approvals.jsonl"),
+                receipts=receipts_path,
+                approval_id=policy_approval,
+                staged=policy_staged,
+                principal=policy_principal,
+                workspace=workspace,
+            )
+            if authorization.status == "staged":
+                return {"status": "staged", "operation_id": plan.operation_id, "plan": plan.as_dict(), "policy": authorization.as_dict()}
+            if authorization.effective_action != authorization.action:
+                raise MergeError("policy transform is not supported by the native merge adapter")
+        try:
+            if policy is not None:
+                policy.recheck(authorization)
+            native_result = _normalize_result(client.submit_merge(plan))
+        except FeatureUnavailable:
+            return fallback_plan(plan, "native GitHub Stack Merge is unavailable for this repository")
+        except StackSyncError as exc:
+            # A transport timeout after the PUT may have created a request. Never issue a blind retry.
+            result = {
+                "status": "indeterminate",
+                "action": "stop-and-reconcile",
+                "message": f"submission outcome is unknown; refusing to submit a duplicate: {exc}",
+            }
+            _persist_request(state, plan, result)
+            _save_state(state_path, state)
+            _record_receipt(receipts_path, repository, plan.operation_id, "submit-unknown", result)
+            return result
+        if policy is not None:
+            try:
+                policy.commit(authorization, native_result)
+            except Exception as exc:
+                if policy_error_type is not None and isinstance(exc, policy_error_type):
+                    raise MergeError(str(exc)) from exc
+                raise
+        request_uuid = _uuid_from(native_result)
+        if native_result["status"] == "pending" and not request_uuid:
+            raise MergeError("GitHub returned pending without a merge request UUID")
+        _persist_request(state, plan, native_result, request_uuid=request_uuid)
+        _save_state(state_path, state)
+        _record_receipt(receipts_path, repository, plan.operation_id, "submit", native_result)
+        existing = state["requests"][plan.operation_id]
+    else:
+        native_result = dict(existing.get("last_result") or {"status": existing.get("status")})
+
+    status = str(existing.get("status", native_result.get("status")))
+    request_uuid = existing.get("request_uuid") or _uuid_from(native_result)
+    if status == "pending":
+        if not request_uuid:
+            result = {"status": "indeterminate", "action": "stop-and-reconcile", "message": "pending request has no persisted UUID"}
+            _persist_request(state, plan, result)
+            _save_state(state_path, state)
+            return result
+        latest = native_result
+        for _ in range(poll_attempts):
+            try:
+                latest = _normalize_result(client.poll_merge(plan, request_uuid))
+            except StackSyncError as exc:
+                result = {"status": "indeterminate", "action": "stop-and-reconcile", "message": f"merge polling failed: {exc}"}
+                _persist_request(state, plan, result, request_uuid=request_uuid)
+                _save_state(state_path, state)
+                _record_receipt(receipts_path, repository, plan.operation_id, "poll-unknown", result)
+                return result
+            if latest["status"] != "pending":
+                break
+        if latest["status"] == "pending":
+            _persist_request(state, plan, latest, request_uuid=request_uuid, timed_out=True)
+            _save_state(state_path, state)
+            _record_receipt(receipts_path, repository, plan.operation_id, "poll-timeout", latest)
+            return {**latest, "operation_id": plan.operation_id, "timed_out": True, "request_uuid": request_uuid}
+        native_result = latest
+        status = latest["status"]
+    if status == "enqueued":
+        latest = native_result
+        for _ in range(poll_attempts):
+            try:
+                latest = _normalize_result(client.poll_queue(plan))
+            except StackSyncError as exc:
+                result = {"status": "indeterminate", "action": "stop-and-reconcile", "message": f"merge queue observation failed: {exc}"}
+                _persist_request(state, plan, result, request_uuid=request_uuid)
+                _save_state(state_path, state)
+                _record_receipt(receipts_path, repository, plan.operation_id, "queue-unknown", result)
+                return result
+            if latest["status"] not in {"enqueued", "pending"}:
+                break
+        if latest["status"] in {"enqueued", "pending"}:
+            if latest["status"] == "pending":
+                latest = {"status": "enqueued", "details": {"message": "merge queue is still processing"}}
+            _persist_request(state, plan, latest, request_uuid=request_uuid, timed_out=True)
+            _save_state(state_path, state)
+            _record_receipt(receipts_path, repository, plan.operation_id, "queue-pending", latest)
+            return {**latest, "operation_id": plan.operation_id, "timed_out": True}
+        native_result = latest
+    if native_result["status"] in {"merged", "failed"}:
+        result = _terminal_result(client, plan, native_result)
+    else:
+        result = native_result
+    _persist_request(state, plan, result, request_uuid=request_uuid)
+    _save_state(state_path, state)
+    _record_receipt(receipts_path, repository, plan.operation_id, "terminal", result)
+    return {**result, "operation_id": plan.operation_id}
+
+
+def ingest_merge_group_event(state_path: Path, receipts_path: Path, event: Mapping[str, Any], *, operation_id: str | None = None) -> dict[str, Any]:
+    """Attach a checks_requested merge_group delivery to its durable enqueued request."""
+
+    if event.get("action") != "checks_requested":
+        raise MergeError("only merge_group checks_requested events can be correlated")
+    merge_group = event.get("merge_group")
+    if not isinstance(merge_group, Mapping) or not merge_group.get("head_sha"):
+        raise MergeError("merge_group event must contain merge_group.head_sha")
+    repository = ((event.get("repository") or {}).get("full_name") if isinstance(event.get("repository"), Mapping) else None) or ""
+    state = _load_state(state_path)
+    if repository and state.get("repository") and repository != state["repository"]:
+        raise MergeError("merge_group event belongs to a different repository")
+    candidates = [
+        (key, value)
+        for key, value in state["requests"].items()
+        if value.get("status") == "enqueued"
+    ]
+    if operation_id:
+        request = state["requests"].get(operation_id)
+        if not request or request.get("status") != "enqueued":
+            raise MergeError("operation is not an enqueued native merge request")
+        selected = [(operation_id, request)]
+    elif len(candidates) == 1:
+        selected = candidates
+    else:
+        raise MergeError("merge_group event is ambiguous; pass --operation-id")
+    selected_id, request = selected[0]
+    plan = MergePlan.from_mapping(request["plan"])
+    if merge_group.get("base_ref") and merge_group["base_ref"] != plan.base_ref:
+        raise ConflictError("merge_group base ref does not match the originating stack plan")
+    summary = {
+        "head_sha": str(merge_group["head_sha"]),
+        "base_ref": str(merge_group.get("base_ref") or plan.base_ref),
+        "head_ref": str(merge_group.get("head_ref") or ""),
+        "delivery_id": str(event.get("delivery_id") or event.get("id") or ""),
+        "checks_requested": True,
+    }
+    request["queue"] = {**request.get("queue", {}), "checks_requested": True, "last_merge_group": summary}
+    state["requests"][selected_id] = request
+    _save_state(state_path, state)
+    _record_receipt(receipts_path, state.get("repository", ""), selected_id, "merge-group", {"status": "enqueued", "merge_group": summary})
+    return {"status": "enqueued", "operation_id": selected_id, "merge_group": summary}
+
+
+class GitHubStackMergeClient(sync.GitHubStackClient):
+    """gh-backed native merge client with explicit async and queue observation."""
+
+    def submit_merge(self, plan: MergePlan) -> dict[str, Any]:
+        path = f"repos/{self.repository}/pulls/{plan.target_pr}/merge-async"
+        try:
+            response = self.request("PUT", path, plan.request_payload())
+        except FeatureUnavailable:
+            raise
+        except sync.ApiError as exc:
+            if exc.status == 404:
+                raise FeatureUnavailable("GitHub Stack Merge is unavailable for this repository") from exc
+            if exc.status == 409:
+                request_uuid = _uuid_from(getattr(exc, "data", None) or str(exc))
+                if request_uuid:
+                    return {"status": "pending", "recovered": True, "details": {"uuid": request_uuid, "message": "reused existing merge request"}}
+                raise MergeError("GitHub reported an existing merge request without its UUID; inspect before retrying") from exc
+            if exc.status == 400:
+                return {"status": "failed", "details": {"message": str(exc)}}
+            raise
+        if not isinstance(response, Mapping):
+            raise MergeError("GitHub async merge response was not an object")
+        return dict(response)
+
+    def poll_merge(self, plan: MergePlan, request_uuid: str) -> dict[str, Any]:
+        path = f"repos/{self.repository}/pulls/{plan.target_pr}/merge-async/{request_uuid}"
+        try:
+            response = self.request("GET", path)
+        except sync.ApiError as exc:
+            if exc.status == 404:
+                raise MergeError("native merge request expired or is no longer readable; refusing a duplicate submit") from exc
+            raise
+        if not isinstance(response, Mapping):
+            raise MergeError("GitHub async merge result was not an object")
+        return dict(response)
+
+    def verify_plan(self, plan: MergePlan) -> dict[str, Any]:
+        remote = self.stack_for_pull_request(plan.target_pr)
+        if remote is None or remote.number != plan.stack_number:
+            raise ConflictError("native stack identity changed before submit")
+        actual = {item.number: item.head_sha for item in remote.pull_requests}
+        for number, expected in zip(plan.selected_pull_requests, plan.expected_head_shas):
+            if actual.get(number) != expected:
+                raise ConflictError(f"PR #{number} head SHA changed before submit")
+        if plan.base_sha and remote.base_sha and plan.base_sha != remote.base_sha:
+            raise ConflictError("native stack base SHA changed before submit")
+        return {"status": "verified", "stack_number": remote.number}
+
+    def preflight_plan(self, plan: MergePlan) -> dict[str, Any]:
+        """Collect available GitHub evidence; unknown gates fail closed by default."""
+
+        checks: list[dict[str, Any]] = []
+        for number, expected_sha in zip(plan.selected_pull_requests, plan.expected_head_shas):
+            data = self.request("GET", f"repos/{self.repository}/pulls/{number}")
+            if not isinstance(data, Mapping):
+                raise MergeError(f"PR #{number} readiness response was not an object")
+            checks.extend(
+                [
+                    {
+                        "name": f"pr-{number}-open",
+                        "status": "pass" if data.get("state") == "open" else "fail",
+                        "message": "open" if data.get("state") == "open" else f"state={data.get('state')}",
+                    },
+                    {
+                        "name": f"pr-{number}-head-sha",
+                        "status": "pass" if (data.get("head") or {}).get("sha") == expected_sha else "fail",
+                        "message": "matches preview" if (data.get("head") or {}).get("sha") == expected_sha else "head SHA changed",
+                    },
+                    self._field_gate(data, number, "mergeability", ("mergeable_state", "mergeStateStatus"), {"clean"}),
+                    self._field_gate(data, number, "reviews", ("review_decision", "reviewDecision"), {"approved", "APPROVED"}),
+                    self._field_gate(data, number, "required-checks", ("required_checks", "requiredChecks"), {"pass", "passed", "success"}),
+                    self._field_gate(data, number, "unresolved-threads", ("unresolved_threads", "unresolvedThreads"), {0}),
+                    self._field_gate(data, number, "rulesets", ("rulesets", "ruleset_status"), {"pass", "passed", "active"}),
+                ]
+            )
+        if plan.merge_action == "merge_queue":
+            checks.append(self._field_gate({}, plan.target_pr, "queue-policy", ("queue_policy",), {"pass", "enabled", "required"}))
+        else:
+            checks.append({"name": "queue-policy", "status": "pass", "message": "not required for direct merge"})
+        failures = [check for check in checks if check["status"] == "fail"]
+        unknown = [check for check in checks if check["status"] == "unknown"]
+        return {
+            "status": "fail" if failures else ("unknown" if unknown else "pass"),
+            "checks": checks,
+            "message": "; ".join(check["message"] for check in failures + unknown),
+        }
+
+    @staticmethod
+    def _field_gate(data: Mapping[str, Any], number: int, name: str, fields: tuple[str, ...], passing: set[Any]) -> dict[str, Any]:
+        value = next((data[field] for field in fields if field in data), None)
+        if value is None:
+            return {"name": f"pr-{number}-{name}", "status": "unknown", "message": "GitHub did not expose this gate"}
+        if isinstance(value, Mapping):
+            value = value.get("status")
+        if isinstance(value, list):
+            value = "pass" if all(str(item.get("conclusion", item.get("status", ""))).lower() in {"success", "passed", "skipped", "neutral"} for item in value if isinstance(item, Mapping)) else "fail"
+        normalized = str(value).lower() if not isinstance(value, (int, float)) else value
+        accepted = {str(item).lower() if not isinstance(item, (int, float)) else item for item in passing}
+        return {"name": f"pr-{number}-{name}", "status": "pass" if normalized in accepted else "fail", "message": str(value)}
+
+    def observe_plan(self, plan: MergePlan) -> dict[str, Any]:
+        merged: list[int] = []
+        closed: list[int] = []
+        open_prs: list[int] = []
+        for number in plan.selected_pull_requests:
+            data = self.request("GET", f"repos/{self.repository}/pulls/{number}")
+            if not isinstance(data, Mapping):
+                continue
+            if data.get("merged_at") or data.get("mergedAt") or data.get("state") == "merged":
+                merged.append(number)
+            elif data.get("state") == "closed":
+                closed.append(number)
+            else:
+                open_prs.append(number)
+        status = "merged" if len(merged) == len(plan.selected_pull_requests) else ("failed" if closed else "pending")
+        return {"status": status, "merged_prs": merged, "closed_prs": closed, "open_prs": open_prs}
+
+    def poll_queue(self, plan: MergePlan) -> dict[str, Any]:
+        observed = self.observe_plan(plan)
+        if observed["status"] == "merged":
+            return {"status": "merged", "details": {"message": "all selected PRs merged from the queue"}, "observed": observed}
+        if observed["closed_prs"]:
+            return {
+                "status": "failed",
+                "details": {"message": f"merge queue ejected or closed PRs: {observed['closed_prs']}"},
+                "observed": observed,
+            }
+        return {"status": "enqueued", "details": {"message": "merge queue is still processing"}, "observed": observed}
+
+
+def _resolve_pr(client: GitHubStackMergeClient, repo_path: Path, pr: int | None, url: str | None, branch: str | None) -> int:
+    return sync.resolve_pr_number(client, repo_path, pr, url, branch)
+
+
+def _path(value: Path, repo_path: Path) -> Path:
+    return value if value.is_absolute() else repo_path / value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Safely land native GitHub Stacked PRs through async Stack Merge.")
+    parser.add_argument("--repo", required=True, help="GitHub repository OWNER/REPO")
+    parser.add_argument("--repo-path", type=Path, default=Path.cwd())
+    parser.add_argument("--manifest", type=Path, default=Path(".forge/stack.json"))
+    parser.add_argument("--state", type=Path, default=Path(".forge/stack-merge.json"))
+    parser.add_argument("--receipts", type=Path, default=Path(".forge/receipts.jsonl"))
+    parser.add_argument("--api", choices=("rest", "graphql"), default="rest")
+    parser.add_argument("--authority", choices=("local", "github"), default="local")
+    parser.add_argument("--policy-profile", type=Path)
+    parser.add_argument("--policy-approval")
+    parser.add_argument("--policy-approvals", type=Path, default=Path(".forge/approvals.jsonl"))
+    parser.add_argument("--policy-staged", action="store_true")
+    parser.add_argument("--policy-principal")
+    parser.add_argument("--merge-method", choices=("merge", "squash", "rebase"), default="merge")
+    parser.add_argument("--merge-action", choices=("default", "direct_merge", "merge_queue"), default="default")
+    parser.add_argument("--poll-attempts", type=int, default=10)
+    parser.add_argument("--allow-unknown-readiness", action="store_true")
+    parser.add_argument("--yes", action="store_true")
+    parser.add_argument("--pr", type=int)
+    parser.add_argument("--url")
+    parser.add_argument("--branch")
+    parser.add_argument("--operation-id")
+    parser.add_argument("--event", type=Path)
+    parser.add_argument("--json", action="store_true")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("plan", help="show the exact native merge preview")
+    sub.add_parser("submit", help="submit or resume an approved native merge")
+    sub.add_parser("poll", help="resume polling a persisted native merge request")
+    sub.add_parser("queue-event", help="correlate a merge_group checks_requested payload")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_path = args.repo_path.resolve()
+    state_path = _path(args.state, repo_path)
+    receipts_path = _path(args.receipts, repo_path)
+    try:
+        if args.command == "queue-event":
+            if not args.event:
+                raise MergeError("queue-event requires --event JSON")
+            event = json.loads(args.event.read_text(encoding="utf-8"))
+            result = ingest_merge_group_event(state_path, receipts_path, event, operation_id=args.operation_id)
+        else:
+            manifest_path = _path(args.manifest, repo_path)
+            manifest = sync.load_stack_manifest(manifest_path)
+            client = GitHubStackMergeClient(args.repo)
+            if args.command == "poll" and args.operation_id:
+                state = _load_state(state_path, args.repo)
+                record = state["requests"].get(args.operation_id)
+                if not record:
+                    raise MergeError(f"no native merge request {args.operation_id}")
+                plan = MergePlan.from_mapping(record["plan"])
+            else:
+                target_pr = _resolve_pr(client, repo_path, args.pr, args.url, args.branch)
+                try:
+                    remote = client.stack_from_graphql(target_pr) if args.api == "graphql" else client.stack_for_pull_request(target_pr)
+                except FeatureUnavailable as exc:
+                    plan = MergePlan(0, target_pr, str(manifest.get("trunk") or "main"), "", (target_pr,), ("unknown",), args.merge_method, args.merge_action, {"status": "unknown"})
+                    result = fallback_plan(plan, str(exc))
+                    print(json.dumps(result, indent=2, sort_keys=True))
+                    return 0
+                plan = plan_merge(
+                    manifest,
+                    remote,
+                    target_pr=target_pr,
+                    merge_method=args.merge_method,
+                    merge_action=args.merge_action,
+                )
+            if args.command == "plan":
+                try:
+                    readiness = client.preflight_plan(plan)
+                except StackSyncError as exc:
+                    readiness = {"status": "unknown", "checks": [], "message": str(exc)}
+                result = {"status": "planned", "plan": MergePlan(**{**plan.__dict__, "readiness": dict(readiness)}).as_dict()}
+            else:
+                result = execute_merge(
+                    client,
+                    args.repo,
+                    plan,
+                    state_path,
+                    receipts_path,
+                    yes=args.yes or args.command == "poll",
+                    authority=args.authority,
+                    policy_profile=args.policy_profile,
+                    policy_approval=args.policy_approval,
+                    policy_staged=args.policy_staged,
+                    policy_approvals_path=_path(args.policy_approvals, repo_path),
+                    policy_principal=args.policy_principal,
+                    workspace=repo_path,
+                    poll_attempts=args.poll_attempts,
+                    allow_unknown_readiness=args.allow_unknown_readiness,
+                    allow_submit=args.command == "submit",
+                )
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except (OSError, StackSyncError, MergeError, ValueError, json.JSONDecodeError) as exc:
+        error = {"error": {"code": type(exc).__name__, "message": str(exc)}}
+        print(json.dumps(error, indent=2) if args.json else f"forge-stack-merge: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/forge/skills/stacked-changes/scripts/forge-stack-sync.py
+++ b/plugins/forge/skills/stacked-changes/scripts/forge-stack-sync.py
@@ -30,10 +30,11 @@ class FeatureUnavailable(StackSyncError):
 
 
 class ApiError(StackSyncError):
-    def __init__(self, status: int, message: str, path: str) -> None:
+    def __init__(self, status: int, message: str, path: str, data: Any = None) -> None:
         super().__init__(f"GitHub API {status} for {path}: {message}")
         self.status = status
         self.path = path
+        self.data = data
 
 
 class ConflictError(StackSyncError):
@@ -217,9 +218,20 @@ class GitHubStackClient:
         if result.returncode:
             status = _error_status(result.stderr)
             message = result.stderr.strip() or result.stdout.strip() or "request failed"
+            response_data = None
+            for candidate in (result.stdout.strip(), result.stderr.strip()):
+                if not candidate:
+                    continue
+                try:
+                    parsed = json.loads(candidate)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, (dict, list)):
+                    response_data = parsed
+                    break
             if status == 404 and "/stacks" in path:
                 raise FeatureUnavailable("GitHub native Stacked PRs are unavailable for this repository")
-            raise ApiError(status, message, path)
+            raise ApiError(status, message, path, response_data)
         if not result.stdout.strip():
             return None
         try:

--- a/policies/github-mutation.json
+++ b/policies/github-mutation.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "profile": "github-mutation",
-  "description": "GitHub mutation profile for issue-ledger and native stacked-PR adapters.",
+  "description": "GitHub mutation profile for issue-ledger, native stacked-PR, and Stack Merge adapters.",
   "default_decision": "deny",
   "protected_paths": [
     "AGENTS.md",
@@ -75,6 +75,22 @@
         "max_fan_out": 10
       },
       "reason": "Native stacked-PR mutations require one scoped approval."
+    },
+    {
+      "id": "github-stack-merge",
+      "decision": "require_approval",
+      "match": {
+        "tool": "forge-stack-merge.submit",
+        "intent": {
+          "external": true,
+          "effect": "github_stack_merge"
+        }
+      },
+      "constraints": {
+        "allowed_domains": ["github.com"],
+        "max_fan_out": 10
+      },
+      "reason": "Native Stack Merge and Merge Queue handoff require one scoped approval."
     }
   ]
 }

--- a/scripts/forge-stack-merge.py
+++ b/scripts/forge-stack-merge.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Convenience entry point for Forge's native GitHub Stack Merge adapter."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+TARGET = Path(__file__).resolve().parents[1] / "plugins/forge/skills/stacked-changes/scripts/forge-stack-merge.py"
+
+
+if __name__ == "__main__":
+    runpy.run_path(str(TARGET), run_name="__main__")

--- a/tests/fixtures/stack-merge/enqueued.json
+++ b/tests/fixtures/stack-merge/enqueued.json
@@ -1,0 +1,6 @@
+{
+  "status": "enqueued",
+  "details": {
+    "message": "Pull request was added to the merge queue."
+  }
+}

--- a/tests/fixtures/stack-merge/failed.json
+++ b/tests/fixtures/stack-merge/failed.json
@@ -1,0 +1,6 @@
+{
+  "status": "failed",
+  "details": {
+    "message": "Merge conflict: the pull request could not be merged."
+  }
+}

--- a/tests/fixtures/stack-merge/merge-group-checks-requested.json
+++ b/tests/fixtures/stack-merge/merge-group-checks-requested.json
@@ -1,0 +1,12 @@
+{
+  "action": "checks_requested",
+  "delivery_id": "f7d2b6e2-1b0a-4dc7-8a42-2a0b6a1c2e10",
+  "merge_group": {
+    "base_ref": "main",
+    "head_ref": "gh-readonly-queue/main/pr-102-7",
+    "head_sha": "queue-head-sha"
+  },
+  "repository": {
+    "full_name": "owner/repo"
+  }
+}

--- a/tests/fixtures/stack-merge/merged.json
+++ b/tests/fixtures/stack-merge/merged.json
@@ -1,0 +1,7 @@
+{
+  "status": "merged",
+  "details": {
+    "message": "Pull request was merged.",
+    "sha": "merge-commit-sha"
+  }
+}

--- a/tests/fixtures/stack-merge/pending.json
+++ b/tests/fixtures/stack-merge/pending.json
@@ -1,0 +1,7 @@
+{
+  "status": "pending",
+  "details": {
+    "message": "Merge request is in progress.",
+    "uuid": "630b9d5e-3f2a-4f7e-8b0c-2d5f9a8c1e42"
+  }
+}

--- a/tests/fixtures/stack-merge/stale.json
+++ b/tests/fixtures/stack-merge/stale.json
@@ -1,0 +1,5 @@
+{
+  "expected_head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "actual_head_sha": "9fd7c8b0b7f6f1e3f0b54c6b9d26a0dd4a4e6f2c",
+  "status": "stale"
+}

--- a/tests/fixtures/stack-merge/unsupported.json
+++ b/tests/fixtures/stack-merge/unsupported.json
@@ -1,0 +1,5 @@
+{
+  "fallback": true,
+  "reason": "GitHub Stack Merge is unavailable for this repository",
+  "status": "fallback"
+}

--- a/tests/test_forge_stack_merge.py
+++ b/tests/test_forge_stack_merge.py
@@ -1,0 +1,304 @@
+"""Behavioral tests for native GitHub Stack Merge and Merge Queue tracking."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "plugins/forge/skills/stacked-changes/scripts/forge-stack-merge.py"
+FIXTURES = REPO / "tests/fixtures/stack-merge"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("forge_stack_merge", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_remote(module):
+    return module.RemoteStack(
+        stack_id=42,
+        number=7,
+        node_id="stack-node",
+        base_ref="main",
+        base_sha="base-sha",
+        pull_requests=(
+            module.RemotePullRequest(101, "feature/auth", "sha-auth", "main", "base-sha"),
+            module.RemotePullRequest(102, "feature/api", "sha-api", "feature/auth", "sha-auth"),
+            module.RemotePullRequest(103, "feature/ui", "sha-ui", "feature/api", "sha-api"),
+        ),
+    )
+
+
+def make_manifest():
+    return {
+        "version": 1,
+        "provider": "github",
+        "trunk": "main",
+        "remote": "origin",
+        "branches": [
+            {"name": "feature/auth", "parent": "main", "pr": 101, "github": {"head_sha": "sha-auth"}},
+            {"name": "feature/api", "parent": "feature/auth", "pr": 102, "github": {"head_sha": "sha-api"}},
+            {"name": "feature/ui", "parent": "feature/api", "pr": 103, "github": {"head_sha": "sha-ui"}},
+        ],
+    }
+
+
+def fixture(name):
+    return json.loads((FIXTURES / name).read_text())
+
+
+class FakeClient:
+    def __init__(self, module, remote, responses, observed=None):
+        self.module = module
+        self.remote = remote
+        self.responses = list(responses)
+        self.observed = observed or {"status": "pending", "merged_prs": [], "open_prs": [101, 102]}
+        self.submit_count = 0
+        self.poll_count = 0
+        self.queue_count = 0
+
+    def verify_plan(self, plan):
+        return {"status": "verified", "stack_number": plan.stack_number}
+
+    def preflight_plan(self, plan):
+        return {"status": "pass", "checks": [{"name": "fixture", "status": "pass"}]}
+
+    def submit_merge(self, plan):
+        self.submit_count += 1
+        return self.responses.pop(0)
+
+    def poll_merge(self, plan, request_uuid):
+        self.poll_count += 1
+        return self.responses.pop(0)
+
+    def poll_queue(self, plan):
+        self.queue_count += 1
+        return self.responses.pop(0) if self.responses else self.observed
+
+    def observe_plan(self, plan):
+        return self.observed
+
+
+def test_plan_previews_exact_contiguous_range_and_expected_sha():
+    module = load_module()
+
+    plan = module.plan_merge(make_manifest(), make_remote(module), target_pr=102, merge_method="squash", merge_action="direct_merge")
+
+    assert plan.selected_pull_requests == (101, 102)
+    assert plan.expected_head_shas == ("sha-auth", "sha-api")
+    assert plan.request_payload() == {"merge_action": "direct_merge", "merge_method": "squash", "sha": "sha-api"}
+    assert plan.expected_result == "merged"
+    assert plan.as_dict()["preview"]["contiguous_range"] == [101, 102]
+
+
+def test_plan_refuses_manifest_head_drift_before_approval():
+    module = load_module()
+    manifest = make_manifest()
+    manifest["branches"][1]["github"]["head_sha"] = "stale-sha"
+
+    with pytest.raises(module.ConflictError, match="PR #102 head SHA changed"):
+        module.plan_merge(manifest, make_remote(module), target_pr=102)
+
+
+def test_plan_refuses_a_non_contiguous_or_closed_range():
+    module = load_module()
+    remote = make_remote(module)
+    remote = module.RemoteStack(
+        remote.stack_id,
+        remote.number,
+        remote.node_id,
+        remote.base_ref,
+        remote.base_sha,
+        (remote.pull_requests[0], module.RemotePullRequest(102, "feature/api", "sha-api", "feature/auth", "sha-auth", state="closed"), remote.pull_requests[2]),
+    )
+
+    with pytest.raises(module.MergeError, match="closed"):
+        module.plan_merge(make_manifest(), remote, target_pr=103)
+
+
+def test_timeout_persists_uuid_and_retry_resumes_without_duplicate_submission(tmp_path):
+    module = load_module()
+    plan = module.plan_merge(make_manifest(), make_remote(module), target_pr=102)
+    client = FakeClient(
+        module,
+        make_remote(module),
+        responses=[
+            {"status": "pending", "details": {"uuid": "request-1", "message": "accepted"}},
+            {"status": "pending", "details": {"uuid": "request-1", "message": "still running"}},
+            {"status": "pending", "details": {"uuid": "request-1", "message": "still running"}},
+        ],
+    )
+    state = tmp_path / "merge.json"
+    receipts = tmp_path / "receipts.jsonl"
+
+    first = module.execute_merge(client, "owner/repo", plan, state, receipts, yes=True, poll_attempts=1)
+    second = module.execute_merge(client, "owner/repo", plan, state, receipts, yes=True, poll_attempts=1)
+
+    assert first["status"] == "pending"
+    assert first["timed_out"] is True
+    assert second["status"] == "pending"
+    assert client.submit_count == 1
+    saved = json.loads(state.read_text())
+    assert saved["requests"][plan.operation_id]["request_uuid"] == "request-1"
+
+
+@pytest.mark.parametrize("status", ["merged", "enqueued", "failed"])
+def test_terminal_submit_states_are_persisted(status, tmp_path):
+    module = load_module()
+    plan = module.plan_merge(make_manifest(), make_remote(module), target_pr=102)
+    observed = {"status": "merged", "merged_prs": [101, 102], "open_prs": []} if status == "merged" else None
+    client = FakeClient(module, make_remote(module), [fixture(f"{status}.json")], observed=observed)
+
+    result = module.execute_merge(client, "owner/repo", plan, tmp_path / "merge.json", tmp_path / "receipts.jsonl", yes=True, poll_attempts=1)
+
+    assert result["status"] == status
+    stored = json.loads((tmp_path / "merge.json").read_text())["requests"][plan.operation_id]
+    assert stored["status"] == status
+
+
+def test_failed_request_with_remote_merge_evidence_is_indeterminate(tmp_path):
+    module = load_module()
+    plan = module.plan_merge(make_manifest(), make_remote(module), target_pr=102, merge_action="direct_merge")
+    client = FakeClient(
+        module,
+        make_remote(module),
+        [{"status": "failed", "details": {"message": "rule failure"}}],
+        observed={"status": "partial", "merged_prs": [101], "open_prs": [102]},
+    )
+
+    result = module.execute_merge(client, "owner/repo", plan, tmp_path / "merge.json", tmp_path / "receipts.jsonl", yes=True)
+
+    assert result["status"] == "indeterminate"
+    assert result["action"] == "stop-and-reconcile"
+    assert result["partial_merge_detected"] is True
+
+
+def test_unsupported_native_merge_returns_provider_fallback(tmp_path):
+    module = load_module()
+    plan = module.plan_merge(make_manifest(), make_remote(module), target_pr=102)
+
+    class Unsupported(FakeClient):
+        def submit_merge(self, plan):
+            raise module.FeatureUnavailable("async stack merge is unavailable")
+
+    result = module.execute_merge(Unsupported(module, make_remote(module), []), "owner/repo", plan, tmp_path / "merge.json", tmp_path / "receipts.jsonl", yes=True)
+
+    assert result["status"] == "fallback"
+    assert result["fallback"] is True
+    assert result["provider_plan"]["strategy"] == "provider-native-bottom-up"
+    assert not (tmp_path / "merge.json").exists()
+
+
+def test_policy_staged_merge_never_submits_or_writes_merge_state(tmp_path):
+    module = load_module()
+    plan = module.plan_merge(make_manifest(), make_remote(module), target_pr=102)
+    client = FakeClient(module, make_remote(module), [{"status": "merged", "details": {}}])
+
+    result = module.execute_merge(
+        client,
+        "owner/repo",
+        plan,
+        tmp_path / "merge.json",
+        tmp_path / "receipts.jsonl",
+        yes=False,
+        policy_profile=REPO / "policies/github-mutation.json",
+        policy_staged=True,
+        policy_approvals_path=tmp_path / "approvals.jsonl",
+        workspace=tmp_path,
+    )
+
+    assert result["status"] == "staged"
+    assert client.submit_count == 0
+    assert not (tmp_path / "merge.json").exists()
+
+
+def test_failed_readiness_gate_stops_before_submit(tmp_path):
+    module = load_module()
+    plan = module.plan_merge(make_manifest(), make_remote(module), target_pr=102)
+
+    class NotReady(FakeClient):
+        def preflight_plan(self, plan):
+            return {"status": "fail", "checks": [{"name": "required-checks", "status": "fail", "message": "CI failed"}]}
+
+    client = NotReady(module, make_remote(module), [{"status": "merged", "details": {}}])
+    with pytest.raises(module.MergeError, match="preflight"):
+        module.execute_merge(client, "owner/repo", plan, tmp_path / "merge.json", tmp_path / "receipts.jsonl", yes=True)
+    assert client.submit_count == 0
+    assert not (tmp_path / "merge.json").exists()
+
+
+def test_policy_merge_requires_scoped_approval_before_submit(tmp_path):
+    module = load_module()
+    plan = module.plan_merge(make_manifest(), make_remote(module), target_pr=102)
+    client = FakeClient(module, make_remote(module), [{"status": "merged", "details": {}}])
+
+    with pytest.raises(module.MergeError, match="approval"):
+        module.execute_merge(
+            client,
+            "owner/repo",
+            plan,
+            tmp_path / "merge.json",
+            tmp_path / "receipts.jsonl",
+            yes=True,
+            policy_profile=REPO / "policies/github-mutation.json",
+            policy_approvals_path=tmp_path / "approvals.jsonl",
+            workspace=tmp_path,
+        )
+    assert client.submit_count == 0
+
+
+def test_duplicate_submit_409_reuses_structured_request_uuid():
+    module = load_module()
+    plan = module.plan_merge(make_manifest(), make_remote(module), target_pr=102)
+    client = module.GitHubStackMergeClient("owner/repo")
+
+    def request(method, path, payload=None):
+        raise module.sync.ApiError(
+            409,
+            "an existing merge request is active",
+            path,
+            {"status": "pending", "details": {"uuid": "630b9d5e-3f2a-4f7e-8b0c-2d5f9a8c1e42"}},
+        )
+
+    client.request = request
+
+    result = client.submit_merge(plan)
+
+    assert result["status"] == "pending"
+    assert result["recovered"] is True
+    assert result["details"]["uuid"].startswith("630b9d5e")
+
+
+def test_merge_group_event_is_correlated_to_enqueued_receipt(tmp_path):
+    module = load_module()
+    plan = module.plan_merge(make_manifest(), make_remote(module), target_pr=102, merge_action="merge_queue")
+    client = FakeClient(module, make_remote(module), [{"status": "enqueued", "details": {"message": "queued"}}])
+    state = tmp_path / "merge.json"
+    receipts = tmp_path / "receipts.jsonl"
+    module.execute_merge(client, "owner/repo", plan, state, receipts, yes=True)
+    event = fixture("merge-group-checks-requested.json")
+
+    result = module.ingest_merge_group_event(state, receipts, event, operation_id=plan.operation_id)
+
+    assert result["status"] == "enqueued"
+    assert result["merge_group"]["head_sha"] == "queue-head-sha"
+    saved = json.loads(state.read_text())["requests"][plan.operation_id]
+    assert saved["queue"]["checks_requested"] is True
+
+
+def test_merge_group_event_rejects_wrong_repository_or_action(tmp_path):
+    module = load_module()
+    state = tmp_path / "merge.json"
+    state.write_text(json.dumps({"schema_version": 1, "repository": "owner/repo", "requests": {}}))
+
+    with pytest.raises(module.MergeError, match="checks_requested"):
+        module.ingest_merge_group_event(state, tmp_path / "receipts.jsonl", {"action": "completed", "merge_group": {}}, operation_id="missing")

--- a/zed/skills/commands/forge-cmd-stack.md
+++ b/zed/skills/commands/forge-cmd-stack.md
@@ -4,12 +4,13 @@ description: Plan, inspect, submit, restack, repair, or land a stack of dependen
 disable-model-invocation: true
 ---
 
-Manage the user's stacked-change workflow with the `stacked-changes` skill.
+Manage the user's stacked-change workflow with the `stacked-changes` skill, including the
+native async Stack Merge and Merge Queue receipt workflow.
 
 Use `.forge/stack.json` for branch and PR ancestry. Start with status. Design independent,
 bottom-up changes; validate every branch against its immediate parent; plan submission or
 restacking before changing Git or GitHub. Prefer GitHub's first-party `gh stack` provider
-when available. Require explicit approval before pushes, rebases,
+when available. Use `forge-stack-merge.py` to preview and resume native landing, and require explicit approval before pushes, rebases,
 force-with-lease, PR creation/base edits, or merges. Land parent-first and stop to
 revalidate after each merge. Never use `--force`, rewrite shared branches, or bypass a
 rejected lease.


### PR DESCRIPTION
## Summary

Closes #17.

Adds a first-party GitHub Stack Merge adapter for exact contiguous stack landing with expected-head protection, explicit policy approval, durable async request state, Merge Queue tracking, and provider-native fallback.

## What changed

- `forge-stack-merge.py` previews the selected range, SHAs, merge method/action, readiness gates, policy effect, and expected result.
- `PUT .../merge-async` responses persist request UUIDs; timeout retries poll the existing request instead of submitting again.
- `pending`, `enqueued`, `merged`, `failed`, and `indeterminate` outcomes are receipt-backed.
- `merge_group` `checks_requested` events correlate to enqueued requests.
- Failed results with remote merge evidence stop as `indeterminate` and require reconciliation.
- Unsupported repositories return a provider-native bottom-up fallback plan.
- `github-mutation.json` now requires approval for `github_stack_merge`.

## Verification

- `python3 -m pytest -q` -> 158 passed
- `uvx ruff==0.16.1 check ...` -> passed
- `./scripts/validate.sh` -> passed
- `npx --yes markdownlint-cli2 '**/*.md' --config .markdownlint.yaml` -> 0 issues
- `python3 evals/run.py` -> 312/313 passed, 1 pre-existing Doctor-description warning

## Review note

This path never uses ordinary `gh pr merge` for a native stack. Direct native failure is verified against remote PR state, and any evidence of a partial landing is surfaced rather than hidden.