### PR TITLE
chore(release): prepare Forge 3.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Forge — enterprise-grade agents, orchestration, stacked delivery, catalogs, commands, and hooks for software engineering.",
-    "version": "3.2.0"
+    "version": "3.3.0"
   },
   "plugins": [
     {
       "name": "forge",
       "source": "./plugins/forge",
       "description": "Specialists, orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, GitHub-native stacked delivery, catalogs, commands, and safety hooks.",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "category": "developer-tooling",
       "keywords": ["agents", "skills", "orchestration", "task-ledger", "stacked-prs", "stack-merge", "merge-queue", "policy", "authorization", "github", "hooks", "code-review", "testing", "security"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [3.3.0] — 2026-08-03
+
 ### Added
 
 - **Release provenance** - deterministic Claude, Codex, and `.agents` bundles, SPDX 2.3
@@ -253,7 +255,8 @@ plugin under `plugins/forge/`.
 - **Docs** — getting started, usage patterns, architecture, design rationale, and CI &
   headless usage guides.
 
-[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.3.0...HEAD
+[3.3.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.3.0
 [3.2.0]: https://github.com/AlisinaDevelo/md-files/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/AlisinaDevelo/md-files/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.0.1

--- a/plugins/forge/.claude-plugin/plugin.json
+++ b/plugins/forge/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "forge",
   "displayName": "Forge",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "An enterprise-grade Claude Code toolkit: specialists, orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, GitHub-native stacked delivery, commands, and safety hooks.",
   "author": {
     "name": "Alisina Karimi",

--- a/plugins/forge/.codex-plugin/plugin.json
+++ b/plugins/forge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A Codex engineering toolkit with orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, catalogs, and GitHub-native stacked delivery.",
   "author": {
     "name": "Alisina Karimi",

--- a/tests/test_forge_release.py
+++ b/tests/test_forge_release.py
@@ -12,6 +12,7 @@ import pytest
 REPO = Path(__file__).resolve().parents[1]
 BUILD_SCRIPT = REPO / "scripts/build_release.py"
 VERIFY_SCRIPT = REPO / "scripts/verify_release.py"
+VERSION = json.loads((REPO / "plugins/forge/.claude-plugin/plugin.json").read_text())["version"]
 
 
 def load(path: Path, name: str):
@@ -29,34 +30,34 @@ def test_same_source_epoch_produces_identical_archives_and_manifest(tmp_path):
     first = tmp_path / "first"
     second = tmp_path / "second"
 
-    first_result = build.build_release(REPO, first, "3.2.0", source_epoch=1_754_000_000, enforce_clean=False)
-    second_result = build.build_release(REPO, second, "3.2.0", source_epoch=1_754_000_000, enforce_clean=False)
+    first_result = build.build_release(REPO, first, VERSION, source_epoch=1_754_000_000, enforce_clean=False)
+    second_result = build.build_release(REPO, second, VERSION, source_epoch=1_754_000_000, enforce_clean=False)
 
     assert first_result["commit"] == second_result["commit"]
     for path in sorted(first.iterdir()):
         assert path.read_bytes() == (second / path.name).read_bytes(), path.name
-    verify.verify_release(first / "forge-3.2.0-manifest.json", first, expected_version="3.2.0")
+    verify.verify_release(first / f"forge-{VERSION}-manifest.json", first, expected_version=VERSION)
 
 
 def test_manifest_contains_three_host_archives_and_runtime_dependencies(tmp_path):
     build = load(BUILD_SCRIPT, "forge_release_build_manifest")
 
-    build.build_release(REPO, tmp_path, "3.2.0", source_epoch=1_754_000_000, enforce_clean=False)
-    manifest = json.loads((tmp_path / "forge-3.2.0-manifest.json").read_text())
+    build.build_release(REPO, tmp_path, VERSION, source_epoch=1_754_000_000, enforce_clean=False)
+    manifest = json.loads((tmp_path / f"forge-{VERSION}-manifest.json").read_text())
 
     assert {item["name"] for item in manifest["artifacts"]} >= {
-        "forge-3.2.0-claude.tar.gz",
-        "forge-3.2.0-codex.tar.gz",
-        "forge-3.2.0-agents.tar.gz",
-        "forge-3.2.0-sbom.spdx.json",
+        f"forge-{VERSION}-claude.tar.gz",
+        f"forge-{VERSION}-codex.tar.gz",
+        f"forge-{VERSION}-agents.tar.gz",
+        f"forge-{VERSION}-sbom.spdx.json",
     }
     assert {item["name"] for item in manifest["runtime_dependencies"]} == {"Python", "GitHub CLI"}
     assert all(item["sha256"] and item["size"] > 0 for item in manifest["artifacts"])
-    assert manifest["version_parity"]["claude_plugin"] == "3.2.0"
-    assert manifest["version_parity"]["codex_plugin"] == "3.2.0"
-    assert manifest["version_parity"]["marketplace_plugin"] == "3.2.0"
-    assert manifest["tag"] == "v3.2.0"
-    assert manifest["verification"]["manifest_file"] == "forge-3.2.0-manifest.json"
+    assert manifest["version_parity"]["claude_plugin"] == VERSION
+    assert manifest["version_parity"]["codex_plugin"] == VERSION
+    assert manifest["version_parity"]["marketplace_plugin"] == VERSION
+    assert manifest["tag"] == f"v{VERSION}"
+    assert manifest["verification"]["manifest_file"] == f"forge-{VERSION}-manifest.json"
     assert all(any(item["path"].endswith("LICENSE") for item in artifact["contents"]) for artifact in manifest["artifacts"] if artifact["name"].endswith(".tar.gz"))
 
 
@@ -70,9 +71,9 @@ def test_spdx_validation_rejects_missing_required_fields():
 def test_offline_verification_detects_archive_tampering(tmp_path):
     build = load(BUILD_SCRIPT, "forge_release_build_tamper")
     verify = load(VERIFY_SCRIPT, "forge_release_verify_tamper")
-    build.build_release(REPO, tmp_path, "3.2.0", source_epoch=1_754_000_000, enforce_clean=False)
-    archive = tmp_path / "forge-3.2.0-claude.tar.gz"
+    build.build_release(REPO, tmp_path, VERSION, source_epoch=1_754_000_000, enforce_clean=False)
+    archive = tmp_path / f"forge-{VERSION}-claude.tar.gz"
     archive.write_bytes(archive.read_bytes() + b"tampered")
 
     with pytest.raises(verify.ReleaseVerificationError, match="sha256"):
-        verify.verify_release(tmp_path / "forge-3.2.0-manifest.json", tmp_path, expected_version="3.2.0")
+        verify.verify_release(tmp_path / f"forge-{VERSION}-manifest.json", tmp_path, expected_version=VERSION)


### PR DESCRIPTION
## Release checklist
- bump Claude, Codex, and Claude marketplace manifests to 3.3.0
- move release provenance into the 3.3.0 changelog section
- make provenance tests follow the checked-in plugin version
- publish tag v3.3.0 after merge to exercise deterministic bundles, SPDX SBOM, hashes, and GitHub attestations

## Verification
- python3 -m pytest -q: 162 passed
- ./scripts/validate.sh
- uvx ruff==0.16.1 check ...
- npx --yes markdownlint-cli2 '**/*.md' --config .markdownlint.yaml

Closes #18