### PR TITLE
fix(ci): pin Scorecard to its verified commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- pin `ossf/scorecard-action` to the dereferenced `v2.4.0` commit
- preserve immutable action pinning while satisfying Scorecard publisher verification

The post-merge `main` CI run for PR #37 failed only because Scorecard rejected the annotated tag object as an imposter commit. GitHub resolves `v2.4.0` to `62b2cac7ed8198b15735ed49ab1e5cf35480ba46`.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`
