### PR TITLE
chore(release): Forge 3.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "Forge — enterprise-grade agents, orchestration, stacked delivery, catalogs, commands, and hooks for software engineering.",
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "plugins": [
     {
       "name": "forge",
       "source": "./plugins/forge",
       "description": "Specialists, orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, GitHub-native stacked delivery, catalogs, commands, and safety hooks.",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "homepage": "https://github.com/AlisinaDevelo/md-files/blob/main/docs/getting-started.md",
       "repository": "https://github.com/AlisinaDevelo/md-files",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [3.4.0] — 2026-08-03
+
 ### Added
 
 - **Marketplace publication readiness** - purpose-built privacy, terms, support, and
@@ -262,7 +264,8 @@ plugin under `plugins/forge/`.
 - **Docs** — getting started, usage patterns, architecture, design rationale, and CI &
   headless usage guides.
 
-[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.3.0...HEAD
+[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.4.0...HEAD
+[3.4.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.4.0
 [3.3.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.3.0
 [3.2.0]: https://github.com/AlisinaDevelo/md-files/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/AlisinaDevelo/md-files/compare/v3.0.1...v3.1.0

--- a/docs/marketplace-readiness.md
+++ b/docs/marketplace-readiness.md
@@ -8,7 +8,7 @@ accepted a public directory submission.
 
 | Surface | Current state | Evidence or next action |
 |---|---|---|
-| GitHub repository marketplace | Available | Install from `AlisinaDevelo/md-files`; tag `v3.3.0` is the verified release. |
+| GitHub repository marketplace | Available | Install from `AlisinaDevelo/md-files`; tag `v3.4.0` is the verified release. |
 | Claude Code repository marketplace | Available | `claude plugin marketplace add AlisinaDevelo/md-files` then `claude plugin install forge@forge`. |
 | Codex local/repository marketplace | Available | `codex plugin marketplace add AlisinaDevelo/md-files` then `codex plugin add forge@forge`. |
 | Claude public/curated directory | Not submitted | Do not claim listing or approval; submit only after the checklist below is reviewed. |
@@ -70,7 +70,7 @@ Before any external submission, record a dated result for each case in the issue
 | Near-miss request | Unrelated prompts do not invoke a Forge skill solely because they mention code. |
 | Permission boundary | Read-only work does not require mutation approval; GitHub/release effects remain policy-gated. |
 | Clean install | A fresh user can add the documented repository marketplace and install `forge@forge`. |
-| Upgrade | Version `3.3.0` replaces the prior cache entry without stale skill content. |
+| Upgrade | Version `3.4.0` replaces the prior cache entry without stale skill content. |
 | Uninstall | Removing Forge removes the host registration while leaving the user's repository untouched. |
 | Resource loading | Every declared skill, command, hook, asset, and referenced file loads from the cached plugin root. |
 

--- a/plugins/forge/.claude-plugin/plugin.json
+++ b/plugins/forge/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "forge",
   "displayName": "Forge",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "An enterprise-grade Claude Code toolkit: specialists, orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, GitHub-native stacked delivery, commands, and safety hooks.",
   "author": {
     "name": "Alisina Karimi",

--- a/plugins/forge/.codex-plugin/plugin.json
+++ b/plugins/forge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "A Codex engineering toolkit with orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, catalogs, and GitHub-native stacked delivery.",
   "author": {
     "name": "Alisina Karimi",


### PR DESCRIPTION
## Summary

- bump Claude, Codex, and repository marketplace manifests to `3.4.0`
- publish the marketplace-readiness work from #37 as the minor release
- update changelog links and verified-release documentation

## Verification

- `python3 -m pytest -q` -> 166 passed
- `./scripts/validate.sh` -> all checks passed
- `python3 -m ruff check ...` -> all checks passed
- `npx --yes markdownlint-cli2 "**/*.md"` -> 0 issues
- `shellcheck scripts/marketplace-smoke.sh ...` -> passed
- `python3 evals/run.py` -> 312/313 passed, 1 existing warning, 0 failures
- `python3 evals/run_scenarios.py --adapter all --no-receipts` -> 12 passed, 0 failed
- deterministic `v3.4.0` candidate built and verified offline
- exact Codex archive validator passed
- exact Claude archive strict validator passed

Release publication remains subject to the tag-triggered provenance workflow.
