### PR TITLE
fix(ci): pin CodeQL action to verified commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,6 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload Scorecard results
-        uses: github/codeql-action/upload-sarif@0fa1882f994fbd81a47ab0804f93354f5ea40147 # v3.28.17
+        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- pin `github/codeql-action/upload-sarif` to the dereferenced `v3.28.17` commit
- preserve immutable action pinning and satisfy OpenSSF Scorecard workflow verification

The release candidate CI exposed this after the Scorecard action itself was corrected. GitHub resolves `v3.28.17` to `60168efe1c415ce0f5521ea06d5c2062adbeed1b`.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`
