### PR TITLE
feat(compiler): add semantic capability evidence

### DIFF
--- a/.forge/tasks/0010-semantic-capability-diff.md
+++ b/.forge/tasks/0010-semantic-capability-diff.md
@@ -1,0 +1,30 @@
+---
+id: 0010
+title: Add semantic capability diff evidence
+status: done
+agent: test-engineer
+model: sonnet
+depends_on: [0006]
+---
+
+## Goal
+
+Give reviewers deterministic semantic evidence for capability changes without copying
+instruction bodies into diffs or receipts.
+
+## Acceptance criteria
+
+- [x] Added, removed, renamed, and changed components are categorized deterministically.
+- [x] Body changes report SHA-256 evidence only.
+- [x] Permission, resource, eval, and host-projection changes remain visible.
+- [x] JSON and Markdown output modes are covered by tests.
+
+## Context
+
+The implementation is `scripts/diff_capabilities.py`; it compares arbitrary graph JSON
+files and defaults the after revision to the current canonical graph.
+
+## Notes
+
+Implemented on `feat/capability-diff-migrations`. Raw instruction text is intentionally
+excluded from semantic evidence.

--- a/.forge/tasks/0011-capability-schema-migration.md
+++ b/.forge/tasks/0011-capability-schema-migration.md
@@ -1,0 +1,31 @@
+---
+id: 0011
+title: Add fail-closed v1-to-v2 capability migration
+status: done
+agent: migration-specialist
+model: sonnet
+depends_on: [0006]
+---
+
+## Goal
+
+Provide a reversible, source-parity-checked path from the inventory graph v1 to the
+body-aware graph v2.
+
+## Acceptance criteria
+
+- [x] Unchanged v1 graphs migrate to the canonical v2 graph.
+- [x] Unsupported schema versions, missing components, and changed digests stop with
+      actionable errors.
+- [x] Migration fixtures cover successful and failure paths.
+- [x] The workflow is documented and uses the current compiler import as its target.
+
+## Context
+
+The implementation is `scripts/migrate_capabilities.py`. It refuses to synthesize bodies
+from stale data and instead requires every v1 component to match the current source
+contract before returning v2.
+
+## Notes
+
+Implemented on `feat/capability-diff-migrations`; full repository gates are pending.

--- a/.forge/tasks/README.md
+++ b/.forge/tasks/README.md
@@ -11,3 +11,5 @@
 | 0007 | Render deterministic native and degraded host surfaces | done | devops-engineer | sonnet | 0006 |
 | 0008 | Harden adapter contract and conformance tests | done | test-engineer | sonnet | 0007 |
 | 0009 | Integrate compiler gates and update capability docs | done | docs-writer | sonnet | 0007, 0008 |
+| 0010 | Add semantic capability diff evidence | done | test-engineer | sonnet | 0006 |
+| 0011 | Add fail-closed v1-to-v2 migration | done | migration-specialist | sonnet | 0006 |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Lint with ruff
         uses: astral-sh/ruff-action@146cd51f235777a9bc491eead18e0d5a4b05406a # v3
         with:
-          args: check plugins/forge/hooks/scripts plugins/forge/skills/policy/scripts plugins/forge/skills/stacked-changes/scripts plugins/forge/skills/doctor/scripts plugins/forge/skills/observability/scripts plugins/forge/skills/task-ledger/scripts scripts/build_release.py scripts/compile_capabilities.py scripts/render_capabilities.py scripts/validate_codex_plugin.py scripts/verify_release.py scripts/generate_catalog.py scripts/forge-doctor.py scripts/forge-policy.py scripts/forge-receipts.py scripts/forge-tasks.py scripts/forge-stack-sync.py evals tests
+          args: check plugins/forge/hooks/scripts plugins/forge/skills/policy/scripts plugins/forge/skills/stacked-changes/scripts plugins/forge/skills/doctor/scripts plugins/forge/skills/observability/scripts plugins/forge/skills/task-ledger/scripts scripts/build_release.py scripts/compile_capabilities.py scripts/render_capabilities.py scripts/diff_capabilities.py scripts/migrate_capabilities.py scripts/validate_codex_plugin.py scripts/verify_release.py scripts/generate_catalog.py scripts/forge-doctor.py scripts/forge-policy.py scripts/forge-receipts.py scripts/forge-tasks.py scripts/forge-stack-sync.py evals tests
 
   release-package:
     name: Reproducible release package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project are documented here. The format is based on
 - **Body-aware capability compiler** - upgraded the canonical graph to v2 with embedded
   instructions, semantic permissions, eval links, and deterministic Claude, Codex, Agent
   Skills, and third-party adapter projections.
+- **Semantic capability evidence** - added prompt-safe semantic diffs and fail-closed
+  v1-to-v2 migration checks with source-parity fixtures.
 
 ## [3.5.0] — 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ proven method, scoped tools, and guardrails. Forge encodes that scaffolding:
   deterministically, without relying on the model to remember.
 - **Proven, not asserted.** A real eval harness scores prompts and high-risk behavior
   contracts (312 deterministic checks plus cross-host scenarios and an opt-in LLM judge);
-  175 tests cover safety hooks, task sync, receipts, doctor, policy, stacks, marketplace readiness, capability graph, rendering, and conformance. Run
+  179 tests cover safety hooks, task sync, receipts, doctor, policy, stacks, marketplace readiness, capability graph, rendering, semantic evidence, and conformance. Run
   them yourself — `just check`.
 - **Auditable & self-validating.** Read every prompt and script. CI validates structure,
   runs the tests, and scores the evals on every push. GitHub-backed task ledgers add stable

--- a/docs/capability-ir.md
+++ b/docs/capability-ir.md
@@ -45,6 +45,12 @@ python3 scripts/render_capabilities.py --check
 
 # Inspect a rendered projection without modifying the repository.
 python3 scripts/render_capabilities.py --host agentskills --output /tmp/forge-projection
+
+# Produce prompt-safe semantic evidence between graph revisions.
+python3 scripts/diff_capabilities.py --before /tmp/capabilities-v1.json --format markdown
+
+# Migrate a reviewed v1 graph only when source parity is proven.
+python3 scripts/migrate_capabilities.py --input /tmp/capabilities-v1.json --output /tmp/capabilities-v2.json
 ```
 
 `./scripts/validate.sh` runs both graph and renderer checks, and release packaging refuses
@@ -80,6 +86,12 @@ render_adapter(repo, graph, output, adapter_contract)
 Adapters declare which component kinds are native or shims, their output roots, naming
 prefixes, and extension inventory. Unsafe paths, overlapping native/shim kinds, and
 unsupported component kinds fail closed.
+
+Semantic diffs report component additions, removals, renames, metadata, permission,
+resource, eval, and host-projection changes. Instruction changes are represented by
+SHA-256 digests only; raw instruction bodies are never included in evidence output.
+Migration accepts a v1 graph only when every component, source path, digest, resource
+inventory, risk label, and host projection still matches the current reviewed source.
 
 ## Migration workflow
 

--- a/justfile
+++ b/justfile
@@ -28,7 +28,15 @@ lint-sh:
 
 # Lint python hook scripts (requires ruff)
 lint-py:
-    ruff check plugins/forge/hooks/scripts plugins/forge/skills/*/scripts scripts/compile_capabilities.py scripts/render_capabilities.py scripts/generate_catalog.py tests evals
+    ruff check plugins/forge/hooks/scripts plugins/forge/skills/*/scripts scripts/compile_capabilities.py scripts/render_capabilities.py scripts/diff_capabilities.py scripts/migrate_capabilities.py scripts/generate_catalog.py tests evals
+
+# Compare two capability graph revisions without exposing instruction bodies
+diff-capabilities before after:
+    python3 scripts/diff_capabilities.py --before {{before}} --after {{after}} --format markdown
+
+# Migrate a reviewed v1 graph against the current source tree
+migrate-capabilities input output:
+    python3 scripts/migrate_capabilities.py --input {{input}} --output {{output}}
 
 # Run every check that CI runs
 check: validate test lint-md conformance

--- a/scripts/diff_capabilities.py
+++ b/scripts/diff_capabilities.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Produce prompt-safe semantic evidence for two capability graphs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[1]
+FIELD_ORDER = (
+    "identity",
+    "source",
+    "frontmatter",
+    "triggers",
+    "instructions",
+    "tools",
+    "permissions",
+    "inputs",
+    "outputs",
+    "resources",
+    "scripts",
+    "evals",
+    "risk",
+    "host_projections",
+    "host_extensions",
+    "source_digest",
+)
+
+
+class DiffError(ValueError):
+    """Raised when a graph cannot produce semantic evidence."""
+
+
+def _key(component: dict[str, Any]) -> str:
+    kind = component.get("kind")
+    component_id = component.get("id")
+    if not isinstance(kind, str) or not isinstance(component_id, str):
+        raise DiffError("every component needs a string kind and id")
+    return f"{kind}:{component_id}"
+
+
+def _index(graph: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    components = graph.get("components")
+    if not isinstance(components, list):
+        raise DiffError("capability graph components must be an array")
+    result: dict[str, dict[str, Any]] = {}
+    for component in components:
+        if not isinstance(component, dict):
+            raise DiffError("capability graph components must be objects")
+        key = _key(component)
+        if key in result:
+            raise DiffError(f"duplicate component: {key}")
+        result[key] = component
+    return result
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _safe_summary(field: str, value: Any) -> Any:
+    if field == "instructions":
+        return {"format": value.get("format"), "body_sha256": value.get("body_sha256")} if isinstance(value, dict) else None
+    if field == "frontmatter":
+        return {"keys": sorted(value), "sha256": _digest(value)} if isinstance(value, dict) else None
+    if field == "triggers" and isinstance(value, dict):
+        return {"kind": value.get("kind"), "description_sha256": _digest(value.get("description", ""))}
+    return value
+
+
+def _change(field: str, before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    if field == "instructions":
+        return {
+            "field": field,
+            "before_sha256": before.get("body_sha256"),
+            "after_sha256": after.get("body_sha256"),
+        }
+    if field == "source_digest":
+        return {"field": field, "before_sha256": before.get("source_sha256"), "after_sha256": after.get("source_sha256")}
+    return {
+        "field": field,
+        "before": _safe_summary(field, before.get(field)),
+        "after": _safe_summary(field, after.get(field)),
+    }
+
+
+def _component_changes(before: dict[str, Any], after: dict[str, Any]) -> list[dict[str, Any]]:
+    changes: list[dict[str, Any]] = []
+    for field in FIELD_ORDER:
+        if field == "instructions":
+            changed = before.get("body_sha256") != after.get("body_sha256") or before.get("instructions", {}).get("format") != after.get("instructions", {}).get("format")
+        elif field == "source_digest":
+            changed = before.get("source_sha256") != after.get("source_sha256")
+        else:
+            changed = before.get(field) != after.get(field)
+        if changed:
+            changes.append(_change(field, before, after))
+    return changes
+
+
+def semantic_diff(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    """Return deterministic, prompt-safe semantic changes between two graphs."""
+    before_index = _index(before)
+    after_index = _index(after)
+    removed_keys = sorted(set(before_index) - set(after_index))
+    added_keys = sorted(set(after_index) - set(before_index))
+    renamed: list[dict[str, str]] = []
+    remaining_removed = list(removed_keys)
+    remaining_added = list(added_keys)
+    for removed in removed_keys:
+        candidates = [
+            added
+            for added in remaining_added
+            if added.split(":", 1)[0] == removed.split(":", 1)[0]
+            and before_index[removed].get("source_sha256") == after_index[added].get("source_sha256")
+        ]
+        if len(candidates) == 1:
+            added = candidates[0]
+            renamed.append({"from": removed, "to": added})
+            remaining_removed.remove(removed)
+            remaining_added.remove(added)
+    changed: list[dict[str, Any]] = []
+    for key in sorted(set(before_index) & set(after_index)):
+        changes = _component_changes(before_index[key], after_index[key])
+        if changes:
+            changed.append({"kind": after_index[key]["kind"], "id": after_index[key]["id"], "changes": changes})
+    return {
+        "schema_version": 1,
+        "before": {"schema_version": before.get("schema_version"), "version": before.get("version")},
+        "after": {"schema_version": after.get("schema_version"), "version": after.get("version")},
+        "summary": {
+            "added": len(remaining_added),
+            "changed": len(changed),
+            "removed": len(remaining_removed),
+            "renamed": len(renamed),
+        },
+        "added": [{"kind": after_index[key]["kind"], "id": after_index[key]["id"]} for key in remaining_added],
+        "removed": [{"kind": before_index[key]["kind"], "id": before_index[key]["id"]} for key in remaining_removed],
+        "renamed": renamed,
+        "changed": changed,
+    }
+
+
+def render(value: dict[str, Any], format_name: str) -> str:
+    if format_name == "json":
+        return json.dumps(value, indent=2, ensure_ascii=True, sort_keys=True) + "\n"
+    if format_name != "markdown":
+        raise DiffError(f"unsupported output format: {format_name}")
+    summary = value["summary"]
+    lines = [
+        "# Capability Semantic Diff",
+        "",
+        f"Before schema {value['before']['schema_version']} ({value['before']['version']})",
+        f"After schema {value['after']['schema_version']} ({value['after']['version']})",
+        "",
+        "## Summary",
+        "",
+        f"- Added: {summary['added']}",
+        f"- Changed: {summary['changed']}",
+        f"- Removed: {summary['removed']}",
+        f"- Renamed: {summary['renamed']}",
+    ]
+    for title, key in (("Added", "added"), ("Removed", "removed"), ("Renamed", "renamed"), ("Changed", "changed")):
+        entries = value[key]
+        if not entries:
+            continue
+        lines.extend(("", f"## {title}", ""))
+        for entry in entries:
+            if key == "renamed":
+                lines.append(f"- `{entry['from']}` -> `{entry['to']}`")
+            elif key == "changed":
+                fields = ", ".join(change["field"] for change in entry["changes"])
+                lines.append(f"- `{entry['kind']}:{entry['id']}`: {fields}")
+            else:
+                lines.append(f"- `{entry['kind']}:{entry['id']}`")
+    if all(not value[key] for key in ("added", "removed", "renamed", "changed")):
+        lines.extend(("", "No semantic changes."))
+    return "\n".join(lines) + "\n"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DiffError(f"cannot read {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise DiffError(f"{path} must contain a JSON object")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--before", required=True, type=Path)
+    parser.add_argument("--after", type=Path, default=REPO / "data/capabilities.json")
+    parser.add_argument("--format", choices=("json", "markdown"), default="json", dest="format_name")
+    args = parser.parse_args(argv)
+    try:
+        print(render(semantic_diff(_load(args.before), _load(args.after)), args.format_name), end="")
+    except (OSError, DiffError, TypeError) as exc:
+        print(f"capability diff: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrate_capabilities.py
+++ b/scripts/migrate_capabilities.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Migrate a v1 capability graph to the current canonical v2 graph."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+class MigrationError(ValueError):
+    """Raised when a graph cannot be migrated without losing source behavior."""
+
+
+def _index(graph: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    components = graph.get("components")
+    if not isinstance(components, list):
+        raise MigrationError("components must be an array")
+    result: dict[str, dict[str, Any]] = {}
+    for component in components:
+        if not isinstance(component, dict) or not isinstance(component.get("kind"), str) or not isinstance(component.get("id"), str):
+            raise MigrationError("every component needs a string kind and id")
+        key = f"{component['kind']}:{component['id']}"
+        if key in result:
+            raise MigrationError(f"duplicate component: {key}")
+        result[key] = component
+    return result
+
+
+def migrate_graph(legacy: dict[str, Any], current: dict[str, Any]) -> dict[str, Any]:
+    """Validate and return the canonical v2 graph for an unchanged v1 source tree."""
+    if legacy.get("schema_version") != 1:
+        raise MigrationError("source schema_version must be 1")
+    if current.get("schema_version") != 2:
+        raise MigrationError("target schema_version must be 2")
+    if legacy.get("project") != "forge" or current.get("project") != "forge":
+        raise MigrationError("only the Forge project is supported")
+    legacy_index = _index(legacy)
+    current_index = _index(current)
+    missing = sorted(set(current_index) - set(legacy_index))
+    extra = sorted(set(legacy_index) - set(current_index))
+    if missing:
+        raise MigrationError("missing legacy components: " + ", ".join(missing))
+    if extra:
+        raise MigrationError("legacy components are not present in v2: " + ", ".join(extra))
+    for key in sorted(current_index):
+        old = legacy_index[key]
+        new = current_index[key]
+        for field in ("source", "body_sha256", "source_sha256", "resources", "risk", "host_projections"):
+            if old.get(field) != new.get(field):
+                raise MigrationError(f"{key} {field} changed; migration requires reviewed source parity")
+    return json.loads(json.dumps(current, ensure_ascii=True))
+
+
+def _load_compiler():
+    path = Path(__file__).with_name("compile_capabilities.py")
+    spec = importlib.util.spec_from_file_location("forge_capability_compiler", path)
+    if spec is None or spec.loader is None:
+        raise MigrationError(f"cannot load compiler: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MigrationError(f"cannot read {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise MigrationError(f"{path} must contain a JSON object")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="legacy v1 capability graph")
+    parser.add_argument("--output", required=True, type=Path, help="destination for the migrated v2 graph")
+    args = parser.parse_args(argv)
+    try:
+        migrated = migrate_graph(_load(args.input), _load_compiler().import_graph())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(migrated, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    except (OSError, MigrationError, TypeError) as exc:
+        print(f"capability migration: {exc}", file=sys.stderr)
+        return 1
+    print(f"Migrated v1 capability graph to {args.output}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_capability_diff_migration.py
+++ b/tests/test_capability_diff_migration.py
@@ -1,0 +1,111 @@
+"""Tests for semantic capability evidence and v1-to-v2 migration."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+DIFF_SCRIPT = REPO / "scripts/diff_capabilities.py"
+MIGRATION_SCRIPT = REPO / "scripts/migrate_capabilities.py"
+
+
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def graph() -> dict:
+    return json.loads((REPO / "data/capabilities.json").read_text(encoding="utf-8"))
+
+
+def to_v1(value: dict) -> dict:
+    legacy = copy.deepcopy(value)
+    legacy["$schema"] = "https://github.com/AlisinaDevelo/md-files/schema/capabilities/v1"
+    legacy["schema_version"] = 1
+    legacy["source_contract"].pop("body")
+    for component in legacy["components"]:
+        for field in (
+            "identity",
+            "triggers",
+            "instructions",
+            "tools",
+            "permissions",
+            "inputs",
+            "outputs",
+            "scripts",
+            "evals",
+            "host_extensions",
+        ):
+            component.pop(field)
+    return legacy
+
+
+def test_semantic_diff_reports_safe_categories_and_digest_only_body_changes():
+    module = load_module(DIFF_SCRIPT, "forge_capability_diff")
+    before = graph()
+    after = copy.deepcopy(before)
+    orchestrate = next(item for item in after["components"] if item["id"] == "orchestrate")
+    orchestrate["instructions"]["body"] += "\nsecret prompt text that must not enter evidence"
+    orchestrate["body_sha256"] = "a" * 64
+    orchestrate["permissions"]["effect"] = "read-only"
+    orchestrate["permissions"]["approval"] = "none"
+    removed = next(item for item in after["components"] if item["id"] == "stack")
+    after["components"].remove(removed)
+    renamed = copy.deepcopy(removed)
+    renamed["id"] = "stack-renamed"
+    renamed["identity"]["id"] = "stack-renamed"
+    after["components"].append(renamed)
+    diff = module.semantic_diff(before, after)
+    encoded = json.dumps(diff, sort_keys=True)
+
+    assert diff["summary"] == {"added": 0, "changed": 1, "removed": 0, "renamed": 1}
+    assert diff["renamed"] == [{"from": "command:stack", "to": "command:stack-renamed"}]
+    changed = next(item for item in diff["changed"] if item["id"] == "orchestrate")
+    fields = {item["field"]: item for item in changed["changes"]}
+    assert {"instructions", "permissions"}.issubset(fields)
+    assert fields["instructions"]["before_sha256"] != fields["instructions"]["after_sha256"]
+    assert "secret prompt text" not in encoded
+
+
+def test_semantic_diff_rendering_is_deterministic():
+    module = load_module(DIFF_SCRIPT, "forge_capability_diff_render")
+    value = module.semantic_diff(graph(), graph())
+
+    assert module.render(value, "json") == module.render(value, "json")
+    markdown = module.render(value, "markdown")
+    assert "Capability Semantic Diff" in markdown
+    assert "No semantic changes." in markdown
+
+
+def test_v1_graph_migrates_only_when_source_contract_is_unchanged():
+    module = load_module(MIGRATION_SCRIPT, "forge_capability_migration")
+    current = graph()
+
+    assert module.migrate_graph(to_v1(current), current) == current
+
+    changed = to_v1(current)
+    changed["components"][0]["body_sha256"] = "0" * 64
+    with pytest.raises(module.MigrationError, match="body_sha256"):
+        module.migrate_graph(changed, current)
+
+
+def test_migration_rejects_unsupported_schema_and_missing_components():
+    module = load_module(MIGRATION_SCRIPT, "forge_capability_migration_errors")
+    current = graph()
+    unsupported = to_v1(current)
+    unsupported["schema_version"] = 9
+    with pytest.raises(module.MigrationError, match="schema_version"):
+        module.migrate_graph(unsupported, current)
+
+    missing = to_v1(current)
+    missing["components"] = missing["components"][1:]
+    with pytest.raises(module.MigrationError, match="missing"):
+        module.migrate_graph(missing, current)


### PR DESCRIPTION
## Summary

- add deterministic, prompt-safe semantic diffs for capability graph revisions
- detect additions, removals, renames, metadata, permissions, resources, evals, and host projection changes
- represent instruction changes with SHA-256 digests only
- add fail-closed v1-to-v2 migration with source-parity checks and fixtures
- wire scripts into CI Ruff scope, Just recipes, docs, changelog, and Forge ledger

## Verification

- `179 passed`
- `python3 evals/run.py`: `312/313` checks passed, 1 existing doctor-description warning
- deterministic cross-host scenarios: `12 passed`, `12 skipped` for credentialed live hosts
- `./scripts/validate.sh` passed
- exact CI Ruff scope passed
- Markdownlint and ShellCheck passed

Related: #45, #42