### PR TITLE
feat(release): derive archives from capability projections

### DIFF
--- a/.forge/tasks/0007-projection-renderer.md
+++ b/.forge/tasks/0007-projection-renderer.md
@@ -14,19 +14,18 @@ graph, including nested resources, manifests, and explicit degraded shims.
 
 ## Acceptance criteria
 
-- [ ] Built-in renderers cover native and omitted/shimmed component kinds.
-- [ ] Claude-only command substitutions are removed or adapted at the shim boundary.
-- [ ] Native skill resources and host manifests are copied deterministically.
-- [ ] Repeated renders compare byte-for-byte and are exercised by release gates.
+- [x] Built-in renderers cover native and omitted/shimmed component kinds.
+- [x] Claude-only command substitutions are removed or adapted at the shim boundary.
+- [x] Native skill resources and host manifests are copied deterministically.
+- [x] Repeated renders compare byte-for-byte and are exercised by release gates.
 
 ## Context
 
 The renderer is `scripts/render_capabilities.py`; output is an explicit caller-selected
-directory and never a tracked generated tree. Keep existing hand-authored Zed shims as
-reviewed release artifacts until the bundle migration slice lands.
+directory and never a tracked generated tree. Release packaging now consumes its generated
+surface, while hand-authored Zed files remain reviewed source inputs for install config.
 
 ## Notes
 
 Implemented on `feat/capability-renderer`; focused renderer tests, deterministic snapshots,
-and the release-packager dry run are green. Full bundle/workflow derivation remains a
-follow-up boundary documented in issue #42.
+and the release-packager dry run are green. Bundle/workflow derivation landed in task 0012.

--- a/.forge/tasks/0011-capability-schema-migration.md
+++ b/.forge/tasks/0011-capability-schema-migration.md
@@ -28,4 +28,5 @@ contract before returning v2.
 
 ## Notes
 
-Implemented on `feat/capability-diff-migrations`; full repository gates are pending.
+Implemented on `feat/capability-diff-migrations`; full repository gates passed and the
+change landed in PR #47.

--- a/.forge/tasks/0012-derived-release-surfaces.md
+++ b/.forge/tasks/0012-derived-release-surfaces.md
@@ -1,0 +1,33 @@
+---
+id: 0012
+title: Derive release surfaces from the capability graph
+status: done
+agent: devops-engineer
+model: sonnet
+depends_on: [0007, 0008, 0010, 0011]
+---
+
+## Goal
+
+Make release archives consume graph-rendered host trees and resolved metadata instead of
+packaging separately maintained host instruction surfaces.
+
+## Acceptance criteria
+
+- [x] Claude, Codex, Agent Skills, and Zed-compatible host trees are rendered first.
+- [x] Catalogs, bundles, workflows, manifests, schemas, licenses, and install inputs are
+      included in the rendered release surface.
+- [x] Release archives consume generated paths and preserve executable modes.
+- [x] SPDX and offline verification remain valid with shared archive path namespaces.
+- [x] Repeated release builds remain byte-identical.
+
+## Context
+
+The implementation extends `scripts/render_capabilities.py` with the release-surface
+projection and makes `scripts/build_release.py` archive that output. Existing authored Zed
+files remain source inputs for global install configuration; generated capability shims are
+what enter the release archive.
+
+## Notes
+
+Implemented on `feat/compiler-release-surfaces`; release and Codex archive tests are green.

--- a/.forge/tasks/README.md
+++ b/.forge/tasks/README.md
@@ -13,3 +13,4 @@
 | 0009 | Integrate compiler gates and update capability docs | done | docs-writer | sonnet | 0007, 0008 |
 | 0010 | Add semantic capability diff evidence | done | test-engineer | sonnet | 0006 |
 | 0011 | Add fail-closed v1-to-v2 migration | done | migration-specialist | sonnet | 0006 |
+| 0012 | Derive release surfaces from the capability graph | done | devops-engineer | sonnet | 0007, 0008, 0010, 0011 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project are documented here. The format is based on
   Skills, and third-party adapter projections.
 - **Semantic capability evidence** - added prompt-safe semantic diffs and fail-closed
   v1-to-v2 migration checks with source-parity fixtures.
+- **Graph-derived release surfaces** - release packaging now renders host trees first and
+  archives resolved catalogs, bundles, workflows, manifests, schemas, and Zed install
+  inputs from the canonical graph.
 
 ## [3.5.0] — 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ proven method, scoped tools, and guardrails. Forge encodes that scaffolding:
   deterministically, without relying on the model to remember.
 - **Proven, not asserted.** A real eval harness scores prompts and high-risk behavior
   contracts (312 deterministic checks plus cross-host scenarios and an opt-in LLM judge);
-  179 tests cover safety hooks, task sync, receipts, doctor, policy, stacks, marketplace readiness, capability graph, rendering, semantic evidence, and conformance. Run
+  182 tests cover safety hooks, task sync, receipts, doctor, policy, stacks, marketplace readiness, capability graph, rendering, semantic evidence, and conformance. Run
   them yourself — `just check`.
 - **Auditable & self-validating.** Read every prompt and script. CI validates structure,
   runs the tests, and scores the evals on every push. GitHub-backed task ledgers add stable

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,8 +49,8 @@ degraded host trees.
 
 Markdown remains the reviewed authoring format, while the v2 graph is a body-aware
 intermediate representation. The renderer generates component files, manifests, nested
-skill resources, and explicit shims. Release bundles, workflow metadata, and reviewed Zed
-files remain separate release artifacts until their derivation is migrated in a follow-up.
+skill resources, explicit shims, resolved catalogs, bundles, workflows, and release
+install inputs. Release packaging consumes that generated surface before archiving it.
 
 ## The four component types
 

--- a/docs/capability-ir.md
+++ b/docs/capability-ir.md
@@ -46,6 +46,9 @@ python3 scripts/render_capabilities.py --check
 # Inspect a rendered projection without modifying the repository.
 python3 scripts/render_capabilities.py --host agentskills --output /tmp/forge-projection
 
+# Build all host trees plus resolved catalogs, bundles, workflows, and install inputs.
+python3 scripts/render_capabilities.py --release-surface --output /tmp/forge-release-surface
+
 # Produce prompt-safe semantic evidence between graph revisions.
 python3 scripts/diff_capabilities.py --before /tmp/capabilities-v1.json --format markdown
 
@@ -123,8 +126,9 @@ Markdown as the reviewed authoring format.
 
 ## Current boundary
 
-The body-aware compiler and deterministic component renderer are now in place. The
-renderer generates component files, nested skill resources, built-in manifests, and
-host-specific shims. Release bundles, workflow metadata, and the repository's reviewed
-Zed shims remain explicit release artifacts for now; the next slice should derive those
-surfaces from rendered projections and add semantic-diff and schema-migration reports.
+The body-aware compiler, semantic evidence tools, and deterministic release-surface
+renderer are now in place. Release packaging renders host trees first, then archives the
+rendered Claude, Codex, and Agent Skills-compatible surfaces with resolved catalogs,
+bundles, workflows, manifests, schemas, and Zed install inputs. The remaining major
+follow-up is broader runtime consumption of this contract by the durable orchestration
+and GitHub Agentic Workflows backends.

--- a/docs/release-provenance.md
+++ b/docs/release-provenance.md
@@ -95,9 +95,11 @@ tag.
 - **Mutable tags or release assets:** the manifest records both tag and commit. Protect
   release tags and review any asset replacement; re-run both attestation and offline
   checks after downloading.
-- **Unreviewed generated or executable content:** bundle inputs must be Git-tracked,
-  regular files with reviewed `100644` or `100755` modes. The builder fails on untracked
-  content, symlinks, mode drift, catalog drift, and version mismatch.
+- **Unreviewed generated or executable content:** source inputs must be Git-tracked, and
+  generated bundle files must be regular files with derived `100644` or `100755` modes.
+  The builder renders only from the reviewed capability graph, rejects symlinks and
+  unsupported filesystem entries, and fails on source drift, catalog drift, and version
+  mismatch.
 - **Keyless signing assumptions:** GitHub artifact attestations provide verifiable
   workflow and repository identity through OIDC-backed signing. They do not prove that
   the source was correct or vulnerability-free; consumers still need source review,

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -14,6 +14,7 @@ import stat
 import subprocess
 import sys
 import tarfile
+import tempfile
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
@@ -22,15 +23,41 @@ VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 SCHEMA_VERSION = 1
 IGNORED_GENERATED = {"__pycache__", ".pytest_cache", ".ruff_cache"}
 BUNDLE_SPECS: dict[str, tuple[tuple[str, str], ...]] = {
-    "claude": (("plugins/forge", "forge"), ("LICENSE", "forge/LICENSE")),
-    "codex": (("plugins/forge", "forge"), ("LICENSE", "forge/LICENSE")),
+    "claude": (("plugins/forge", "forge"), ("LICENSE", "forge")),
+    "codex": (("plugins/forge", "forge"), ("LICENSE", "forge")),
     "agents": (
         ("plugins/forge/skills", "forge-agents/skills"),
         ("zed/skills", "forge-agents/zed/skills"),
-        ("zed/AGENTS.md", "forge-agents/zed/AGENTS.md"),
-        ("zed/install.sh", "forge-agents/zed/install.sh"),
-        (".agents/plugins/marketplace.json", "forge-agents/.agents/plugins/marketplace.json"),
-        ("LICENSE", "forge-agents/LICENSE"),
+        ("zed/AGENTS.md", "forge-agents/zed"),
+        ("zed/install.sh", "forge-agents/zed"),
+        (".agents/plugins/marketplace.json", "forge-agents/.agents/plugins"),
+        ("LICENSE", "forge-agents"),
+    ),
+}
+RENDERED_BUNDLE_SPECS: dict[str, tuple[tuple[str, str], ...]] = {
+    "claude": (
+        ("claude/plugins/forge", "forge"),
+        ("claude/CATALOG.md", "forge"),
+        ("claude/data", "forge/data"),
+        ("claude/LICENSE", "forge"),
+    ),
+    "codex": (
+        ("codex/plugins/forge", "forge"),
+        ("codex/CATALOG.md", "forge"),
+        ("codex/data", "forge/data"),
+        ("codex/LICENSE", "forge"),
+    ),
+    "agents": (
+        ("agentskills/plugins/forge/skills", "forge-agents/skills"),
+        ("agentskills/zed/skills", "forge-agents/zed/skills"),
+        ("agentskills/zed/AGENTS.md", "forge-agents/zed"),
+        ("agentskills/zed/README.md", "forge-agents/zed"),
+        ("agentskills/zed/install.sh", "forge-agents/zed"),
+        ("agentskills/zed/settings", "forge-agents/zed/settings"),
+        ("agentskills/.agents/plugins/marketplace.json", "forge-agents/.agents/plugins"),
+        ("agentskills/CATALOG.md", "forge-agents"),
+        ("agentskills/data", "forge-agents/data"),
+        ("agentskills/LICENSE", "forge-agents"),
     ),
 }
 RUNTIME_DEPENDENCIES = (
@@ -129,14 +156,39 @@ def _source_files(repo: Path, source: str, tracked: Mapping[str, str]) -> list[t
     return files
 
 
-def _bundle_files(repo: Path, bundle: str, tracked: Mapping[str, str]) -> list[tuple[str, Path, str]]:
+def _generated_files(root: Path) -> list[tuple[str, Path, str]]:
+    if not root.exists():
+        raise ReleaseBuildError(f"generated release source path is missing: {root}")
+    paths = [root] if root.is_file() else sorted(root.rglob("*"))
+    files: list[tuple[str, Path, str]] = []
+    for path in paths:
+        if path.is_dir():
+            continue
+        relative = path.name if root.is_file() else path.relative_to(root).as_posix()
+        if path.is_symlink():
+            raise ReleaseBuildError(f"symlinks are not allowed in generated bundles: {relative}")
+        file_stat = path.stat()
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ReleaseBuildError(f"generated release input is not a regular file: {relative}")
+        executable = bool(file_stat.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+        files.append((relative, path, "100755" if executable else "100644"))
+    return files
+
+
+def _bundle_files(
+    repo: Path,
+    bundle: str,
+    tracked: Mapping[str, str],
+    generated_root: Path | None = None,
+) -> list[tuple[str, Path, str]]:
     entries: list[tuple[str, Path, str]] = []
     seen: set[str] = set()
-    for source, prefix in BUNDLE_SPECS[bundle]:
-        source_files = _source_files(repo, source, tracked)
-        source_root = repo / source
+    specs = RENDERED_BUNDLE_SPECS[bundle] if generated_root else BUNDLE_SPECS[bundle]
+    for source, prefix in specs:
+        source_root = generated_root / source if generated_root else repo / source
+        source_files = _generated_files(source_root) if generated_root else _source_files(repo, source, tracked)
         for relative, path, mode in source_files:
-            suffix = Path(relative).relative_to(source_root.relative_to(repo)).as_posix() if source_root.is_dir() else Path(relative).name
+            suffix = relative if source_root.is_dir() else Path(relative).name
             archive_path = f"{prefix}/{suffix}"
             if archive_path in seen:
                 raise ReleaseBuildError(f"duplicate archive path in {bundle} bundle: {archive_path}")
@@ -333,12 +385,19 @@ def build_release(
     subprocess.run([sys.executable, str(repo / "scripts/compile_capabilities.py"), "--check"], cwd=repo, check=True)
     subprocess.run([sys.executable, str(repo / "scripts/render_capabilities.py"), "--check"], cwd=repo, check=True)
     bundles: list[dict[str, Any]] = []
-    for surface in ("claude", "codex", "agents"):
-        entries = _bundle_files(repo, surface, tracked)
-        data, contents = _archive(surface, entries, source_epoch)
-        name = f"forge-{version}-{surface}.tar.gz"
-        _write(output / name, data)
-        bundles.append({"surface": surface, "name": name, "size": len(data), "sha256": _sha256_bytes(data), "contents": contents})
+    with tempfile.TemporaryDirectory(prefix="forge-release-surface-") as rendered:
+        subprocess.run(
+            [sys.executable, str(repo / "scripts/render_capabilities.py"), "--release-surface", "--output", rendered],
+            cwd=repo,
+            check=True,
+        )
+        generated_root = Path(rendered)
+        for surface in ("claude", "codex", "agents"):
+            entries = _bundle_files(repo, surface, tracked, generated_root)
+            data, contents = _archive(surface, entries, source_epoch)
+            name = f"forge-{version}-{surface}.tar.gz"
+            _write(output / name, data)
+            bundles.append({"surface": surface, "name": name, "size": len(data), "sha256": _sha256_bytes(data), "contents": contents})
     sbom_name = f"forge-{version}-sbom.spdx.json"
     sbom = _spdx_document(repo, version, tag, commit, source_epoch, bundles)
     sbom_bytes = _canonical(sbom).encode("utf-8")

--- a/scripts/render_capabilities.py
+++ b/scripts/render_capabilities.py
@@ -60,6 +60,7 @@ def _copy(source: Path, target: Path) -> None:
         raise RenderError(f"render source is missing: {source}")
     target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(source, target)
+    shutil.copymode(source, target)
 
 
 def _yaml_value(value: Any) -> str:
@@ -152,6 +153,158 @@ def _copy_extensions(repo: Path, root: Path, host: str, extensions: list[str]) -
                 _copy(path, destination / path.relative_to(source))
                 count += 1
     return count
+
+
+def _load_json(repo: Path, relative: str) -> dict[str, Any]:
+    path = repo / relative
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RenderError(f"cannot read {relative}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RenderError(f"{relative} must contain a JSON object")
+    return value
+
+
+def _reference_map(graph: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    references: dict[str, dict[str, Any]] = {}
+    for component in graph["components"]:
+        kind = component["kind"]
+        component_id = component["id"]
+        reference = f"/{component_id}" if kind == "command" else component_id
+        if reference in references:
+            raise RenderError(f"ambiguous capability reference: {reference}")
+        references[reference] = component
+    return references
+
+
+def _resolve_references(value: str, references: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    slash_names = re.findall(r"/([a-z0-9][a-z0-9-]*)", value)
+    if slash_names:
+        for name in slash_names:
+            reference = f"/{name}"
+            if reference not in references:
+                raise RenderError(f"metadata references unknown capability: {reference}")
+            matches.append(references[reference])
+        return matches
+    if value in references:
+        return [references[value]]
+    return []
+
+
+def _resolved_metadata(graph: dict[str, Any], repo: Path) -> dict[str, dict[str, Any]]:
+    references = _reference_map(graph)
+    output: dict[str, dict[str, Any]] = {}
+    for filename, collection_key, reference_key in (
+        ("data/bundles.json", "bundles", "components"),
+        ("data/workflows.json", "workflows", "steps"),
+    ):
+        source = _load_json(repo, filename)
+        entries = source.get(collection_key)
+        if not isinstance(entries, list):
+            raise RenderError(f"{filename} {collection_key} must be an array")
+        seen: set[str] = set()
+        rendered: list[dict[str, Any]] = []
+        for entry in entries:
+            if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
+                raise RenderError(f"{filename} contains an invalid {collection_key[:-1]} entry")
+            if entry["id"] in seen:
+                raise RenderError(f"{filename} contains duplicate id {entry['id']}")
+            seen.add(entry["id"])
+            references_for_entry = entry.get(reference_key)
+            if not isinstance(references_for_entry, list) or not all(isinstance(item, str) for item in references_for_entry):
+                raise RenderError(f"{filename} {entry['id']} {reference_key} must be a string array")
+            resolved: list[dict[str, Any]] = []
+            for reference in references_for_entry:
+                for component in _resolve_references(reference, references):
+                    resolved.append(
+                        {
+                            "id": component["id"],
+                            "kind": component["kind"],
+                            "source": component["source"],
+                            "host_projections": component["host_projections"],
+                        }
+                    )
+            rendered.append({**entry, "resolved_components" if reference_key == "components" else "resolved_steps": resolved})
+        output[collection_key] = {
+            "schema_version": 2,
+            "source_version": source.get("version"),
+            "capability_graph": {"schema_version": graph["schema_version"], "version": graph["version"]},
+            collection_key: rendered,
+        }
+    return output
+
+
+def _catalog(repo: Path) -> tuple[str, str]:
+    path = repo / "scripts" / "generate_catalog.py"
+    spec = importlib.util.spec_from_file_location("forge_catalog_generator", path)
+    if spec is None or spec.loader is None:
+        raise RenderError(f"cannot load catalog generator: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.REPO = repo
+    module.PLUGIN = repo / "plugins" / "forge"
+    module.CAPABILITIES = repo / "data" / "capabilities.json"
+    return module.render_catalog(module.component_rows())
+
+
+def _copy_zed_surface(repo: Path, root: Path) -> int:
+    count = 0
+    for relative in ("zed/AGENTS.md", "zed/README.md", "zed/install.sh", "zed/settings/profiles.json"):
+        _copy(repo / relative, root / relative)
+        count += 1
+    return count
+
+
+def render_release_surface(repo: Path, graph: dict[str, Any], output: Path) -> dict[str, Any]:
+    """Render hosts plus release metadata and install inputs from one graph."""
+    _validate_graph(graph)
+    reports = render_all(repo, graph, output)
+    resolved_metadata = _resolved_metadata(graph, repo)
+    catalog_markdown, catalog_json = _catalog(repo)
+    graph_json = json.dumps(graph, indent=2, ensure_ascii=True) + "\n"
+    metadata_files = {
+        "CATALOG.md": catalog_markdown,
+        "data/catalog.json": catalog_json,
+        "data/bundles.json": json.dumps(resolved_metadata["bundles"], indent=2, ensure_ascii=True) + "\n",
+        "data/workflows.json": json.dumps(resolved_metadata["workflows"], indent=2, ensure_ascii=True) + "\n",
+        "data/capabilities.json": graph_json,
+    }
+    metadata_sources = (
+        "data/capabilities.schema.json",
+        "data/host-adapter.schema.json",
+    )
+    common_manifest = {
+        "schema_version": 1,
+        "project": "forge",
+        "graph": {"schema_version": graph["schema_version"], "version": graph["version"]},
+        "hosts": {
+            host: {
+                "components": reports[host]["components"],
+                "files": reports[host]["files"] + len(metadata_files) + len(metadata_sources) + 1 + (4 if host == "agentskills" else 0),
+            }
+            for host in HOST_NAMES
+        },
+        "metadata": {key: {"source_version": value["source_version"], "count": len(value[key])} for key, value in resolved_metadata.items()},
+    }
+    for host in HOST_NAMES:
+        root = output / host
+        for relative, content in metadata_files.items():
+            _write(root / relative, content)
+        for relative in metadata_sources:
+            _copy(repo / relative, root / relative)
+        _copy(repo / "LICENSE", root / "LICENSE")
+        if host == "agentskills":
+            _copy_zed_surface(repo, root)
+        _write(root / "data/projection-manifest.json", json.dumps(common_manifest, indent=2, ensure_ascii=True) + "\n")
+        reports[host]["files"] = common_manifest["hosts"][host]["files"] + 1
+    return {
+        "schema_version": 1,
+        "graph": {"schema_version": graph["schema_version"], "version": graph["version"]},
+        "hosts": reports,
+        "metadata": common_manifest["metadata"],
+    }
 
 
 def render_host(repo: Path, graph: dict[str, Any], output: Path, host: str) -> dict[str, Any]:
@@ -275,6 +428,7 @@ def main(argv: list[str] | None = None) -> int:
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--check", action="store_true", help="verify all built-in projections are deterministic")
     mode.add_argument("--adapter", type=Path, help="render a JSON host adapter contract")
+    mode.add_argument("--release-surface", action="store_true", help="render hosts, metadata, and install inputs")
     parser.add_argument("--host", choices=("all", *HOST_NAMES), default="all")
     parser.add_argument("--output", type=Path, default=Path("build/capability-projections"))
     args = parser.parse_args(argv)
@@ -291,6 +445,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.adapter:
             adapter = json.loads(args.adapter.read_text(encoding="utf-8"))
             report = render_adapter(REPO, graph, args.output, adapter)
+        elif args.release_surface:
+            report = render_release_surface(REPO, graph, args.output)
         elif args.host == "all":
             report = render_all(REPO, graph, args.output)
         else:

--- a/tests/test_forge_release.py
+++ b/tests/test_forge_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -59,6 +60,22 @@ def test_manifest_contains_three_host_archives_and_runtime_dependencies(tmp_path
     assert manifest["tag"] == f"v{VERSION}"
     assert manifest["verification"]["manifest_file"] == f"forge-{VERSION}-manifest.json"
     assert all(any(item["path"].endswith("LICENSE") for item in artifact["contents"]) for artifact in manifest["artifacts"] if artifact["name"].endswith(".tar.gz"))
+
+
+def test_archives_consume_host_rendered_surfaces(tmp_path):
+    build = load(BUILD_SCRIPT, "forge_release_build_rendered_surfaces")
+    build.build_release(REPO, tmp_path, VERSION, source_epoch=1_754_000_000, enforce_clean=False)
+
+    with tarfile.open(tmp_path / f"forge-{VERSION}-codex.tar.gz", "r:gz") as archive:
+        codex_names = {member.name for member in archive.getmembers()}
+    with tarfile.open(tmp_path / f"forge-{VERSION}-agents.tar.gz", "r:gz") as archive:
+        agents_names = {member.name for member in archive.getmembers()}
+
+    assert "forge/skills/orchestration/SKILL.md" in codex_names
+    assert "forge/agents/architect.md" not in codex_names
+    assert "forge/data/projection-manifest.json" in codex_names
+    assert "forge-agents/zed/install.sh" in agents_names
+    assert "forge-agents/data/bundles.json" in agents_names
 
 
 def test_spdx_validation_rejects_missing_required_fields():

--- a/tests/test_release_surface_renderer.py
+++ b/tests/test_release_surface_renderer.py
@@ -1,0 +1,55 @@
+"""Tests for graph-derived release surfaces and metadata."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts/render_capabilities.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("forge_release_surface_renderer", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def graph():
+    return json.loads((REPO / "data/capabilities.json").read_text(encoding="utf-8"))
+
+
+def snapshot(root: Path) -> dict[str, bytes]:
+    return {path.relative_to(root).as_posix(): path.read_bytes() for path in root.rglob("*") if path.is_file()}
+
+
+def test_release_surface_derives_metadata_and_install_inputs(tmp_path):
+    module = load_module()
+    report = module.render_release_surface(REPO, graph(), tmp_path)
+
+    assert set(report["hosts"]) == {"claude", "codex", "agentskills"}
+    assert (tmp_path / "claude/CATALOG.md").is_file()
+    bundles = json.loads((tmp_path / "claude/data/bundles.json").read_text(encoding="utf-8"))
+    workflows = json.loads((tmp_path / "claude/data/workflows.json").read_text(encoding="utf-8"))
+    assert bundles["schema_version"] == 2
+    assert workflows["capability_graph"]["schema_version"] == 2
+    assert any(item["resolved_components"] for item in bundles["bundles"])
+    assert any(item["resolved_steps"] for item in workflows["workflows"])
+    assert (tmp_path / "agentskills/zed/install.sh").stat().st_mode & 0o111
+    manifest = json.loads((tmp_path / "codex/data/projection-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["hosts"]["codex"]["components"] == 25
+    assert manifest["metadata"]["bundles"]["count"] == 6
+
+
+def test_release_surface_is_byte_deterministic(tmp_path):
+    module = load_module()
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+
+    module.render_release_surface(REPO, graph(), first)
+    module.render_release_surface(REPO, graph(), second)
+
+    assert snapshot(first) == snapshot(second)


### PR DESCRIPTION
## Summary

- render Claude, Codex, Agent Skills, and Zed-compatible release surfaces from the canonical capability graph
- resolve catalogs, bundles, and workflows into versioned metadata with projection evidence
- make release archives consume generated host trees, schemas, manifests, licenses, and install inputs
- preserve executable modes and fix shared-namespace SPDX coverage for host projections

## Verification

- `182 passed`
- `python3 evals/run.py`: `312/313` checks passed, 1 existing doctor-description warning
- deterministic cross-host scenarios: `12 passed`, `12 skipped` for credentialed live hosts
- `./scripts/validate.sh` passed
- exact CI Ruff scope passed
- Markdownlint and ShellCheck passed
- release archive, Codex validator, reproducibility, SPDX, and offline verification tests passed

Related: #46, #42