### PR TITLE
docs(roadmap): refresh durable runtime research plan

### DIFF
--- a/.forge/tasks/0015-research-runtime-roadmap.md
+++ b/.forge/tasks/0015-research-runtime-roadmap.md
@@ -1,0 +1,51 @@
+---
+id: 0015
+title: Research and refresh the durable runtime roadmap
+status: done
+agent: architect
+model: opus
+depends_on: [0014]
+---
+
+## Goal
+
+Recheck the runtime roadmap against current primary sources and convert the remaining
+durability, safety, evidence, interaction, and backend gaps into executable GitHub issues.
+
+## Acceptance criteria
+
+- [x] The live repository, release state, local ledger, and open GitHub roadmap are recorded.
+- [x] Primary sources cover durable activities, retries, heartbeats, outbox delivery,
+      fencing, checkpoints, human waits, provenance, and merge-queue behavior.
+- [x] Issue #54 includes owner fencing and generation requirements, not only lease expiry.
+- [x] Issues #55-#58 define checkpoint/migration, execution lineage, human waits, and
+      portable backend conformance slices with explicit acceptance criteria.
+- [x] Existing runtime, evidence, routing, gh-aw, and stacked-delivery issues are updated
+      with the research decisions and remain non-overlapping.
+- [x] The next implementation target and release gates are written down for Forge routing.
+
+## Research basis
+
+- [Temporal activity idempotency and heartbeats](https://docs.temporal.io/activity-definition)
+- [Temporal retry policy](https://docs.temporal.io/encyclopedia/retry-policies)
+- [AWS transactional outbox](https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/transactional-outbox.html)
+- [Google Chubby lock sequencers](https://research.google.com/archive/chubby-osdi06.pdf)
+- [LangGraph persistence](https://docs.langchain.com/oss/python/langgraph/persistence)
+- [LangGraph human-in-the-loop](https://docs.langchain.com/oss/python/langchain/human-in-the-loop)
+- [MCP Tasks](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks)
+- [Dapr durable workflow integrity](https://docs.dapr.io/developing-applications/building-blocks/workflow/workflow-features-concepts/)
+- [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/)
+- [SLSA v1.2](https://slsa.dev/spec/v1.2/)
+- [GitHub artifact attestations](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations)
+- [GitHub merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+
+## Outcome
+
+The current main baseline is the merged #53 transactional effect boundary. The next
+implementation target is #54. The proposed durable-runtime sequence is #54 -> #55 -> #56,
+then #57 and #58. The gh-aw compiler (#21) and adaptive routing (#22) remain later slices
+because they need the runtime evidence and policy contracts first.
+
+No release tag or host reinstall was performed by this research task. The repository still
+reports release 3.6.0, while the transactional effect changes remain under Unreleased until
+the next implementation slice and full release validation are complete.

--- a/.forge/tasks/README.md
+++ b/.forge/tasks/README.md
@@ -16,3 +16,4 @@
 | 0012 | Derive release surfaces from the capability graph | done | devops-engineer | sonnet | 0007, 0008, 0010, 0011 |
 | 0013 | Add local runtime event store and deterministic replay | done | architect | opus | - |
 | 0014 | Add transactional runtime outbox and inbox effects | done | concurrency-engineer | sonnet | 0013 |
+| 0015 | Research and refresh the durable runtime roadmap | done | architect | opus | 0014 |

--- a/docs/runtime-roadmap.md
+++ b/docs/runtime-roadmap.md
@@ -1,0 +1,77 @@
+# Runtime Roadmap
+
+Last reviewed: 2026-08-05.
+
+This roadmap is the execution plan for Forge's durable runtime. The event history is the
+source of truth for a run; receipts, task ledgers, provider sessions, MCP Tasks, GitHub
+workflows, and telemetry remain adapters or evidence surfaces.
+
+## Baseline
+
+- Main is clean at the merged transactional effect boundary from #53.
+- The local SQLite/WAL runtime has hash-chained events, deterministic replay, bounded
+  lifecycle transitions, an atomic event-plus-outbox write, leases, retries, dead letters,
+  inbox dedupe, and reference-only payload checks.
+- The current release remains 3.6.0. The transactional effect boundary is documented under
+  `Unreleased`; no new tag should claim it until release validation is repeated.
+- The current stack delivery path already records head/base SHAs, guards mutations, handles
+  Merge Queue observation, and receives `merge_group` CI checks. Stacked delivery is a
+  maintained strength, not a missing parallel abstraction.
+
+## Research decisions
+
+| Area | Industry signal | Forge decision |
+| --- | --- | --- |
+| Activities and effects | Temporal and AWS assume retries or duplicate delivery and require idempotent activities, stable keys, and an atomic outbox boundary. | Keep at-least-once delivery explicit; make adapter idempotency and provider request references mandatory. |
+| Worker ownership | Chubby uses a lock generation sequencer that protected services validate, closing the stale-client write window. | A lease claim must issue a monotonic generation or fencing token; owner and generation are required for heartbeat, completion, failure, and protected effect submission. |
+| Recovery | LangGraph, Microsoft Agent Framework, and Dapr persist checkpoints and durable retry state, including successful work that can be resumed after a sibling failure. | Add hashed checkpoints, suffix replay, crash recovery, and reviewed fail-closed migrations before calling the runtime durable at scale. |
+| Human interaction | MCP Tasks defines `input_required`, TTL, polling hints, cancellation, authorization binding, limits, and audit expectations; provider task state is not enough. | Model waits and signals in Forge history, then expose MCP Tasks as an adapter. |
+| Evidence | OpenTelemetry provides versioned agent/workflow/tool vocabulary; SLSA and in-toto bind evidence to immutable subjects and resolved inputs. | Add a privacy-safe, digest-bound episode lineage and receipt verifier without replacing canonical history or release attestations. |
+| GitHub delivery | GitHub Merge Queue validates checks on the latest target plus queued changes and requires `merge_group` reporting. | Preserve SHA-bound stack plans, queue-event correlation, explicit approval, and indeterminate stop states. |
+
+## Release sequence
+
+### Next runtime slice
+
+1. [#54 Heartbeats and stale-worker fencing](https://github.com/AlisinaDevelo/md-files/issues/54)
+
+The first implementation target. It closes the zombie-worker gap in the existing outbox
+lease protocol. The slice must land with crash and race tests, schemas, CLI inspection, and
+policy-pinned timeout evidence.
+
+### Durable runtime foundation
+
+1. [#55 Checkpointed recovery and migrations](https://github.com/AlisinaDevelo/md-files/issues/55)
+2. [#56 Verifiable execution lineage and receipt integrity](https://github.com/AlisinaDevelo/md-files/issues/56)
+3. [#57 Human-input waits, signals, and cancellation](https://github.com/AlisinaDevelo/md-files/issues/57)
+4. [#58 Portable backend adapter and conformance](https://github.com/AlisinaDevelo/md-files/issues/58)
+
+These issues are the minimum credible v4 runtime contract. They are intentionally separate:
+recovery, evidence, interaction, and backend portability have different failure modes and
+must remain independently reviewable.
+
+### Later integrations
+
+- [#21 GitHub Agentic Workflows](https://github.com/AlisinaDevelo/md-files/issues/21) comes
+  after the runtime can correlate dispatch, workers, safe outputs, and replay.
+- [#22 Adaptive model routing](https://github.com/AlisinaDevelo/md-files/issues/22) comes
+  after outcome evidence, budgets, policy gates, and offline replay are trustworthy.
+- [#8 Connected Control Plane](https://github.com/AlisinaDevelo/md-files/issues/8) and
+  [#9 Evidence and Trust](https://github.com/AlisinaDevelo/md-files/issues/9) remain the
+  compatibility and release tracks for GitHub synchronization, policy, attestations, and
+  cross-host evidence.
+
+## Release gates
+
+Do not call the runtime v4-ready until the following are true:
+
+- A killed worker cannot mutate an effect after reclaim, even when a delayed request arrives.
+- A checkpoint plus suffix replay matches full replay, and corrupt or incompatible state
+  fails closed with a reviewed migration path.
+- Human waits, signals, cancellation, and late responses are deterministic and auditable.
+- At least two backend implementations pass the same conformance fixtures, or the adapter
+  capability report explicitly proves why a second backend is not yet available.
+- Runtime evidence verifies offline without raw prompts, credentials, tool content, or
+  provider response bodies.
+- The exact release archive is reproducible, validated for Claude and Codex, and its
+  artifact attestations verify against the intended source ref.


### PR DESCRIPTION
## Summary

- record the current durable-runtime baseline and release boundary
- capture primary-source decisions for idempotency, fencing, checkpoints, human waits, provenance, and merge queues
- add task 0015 and a concrete runtime roadmap for issues #54-#58
- keep gh-aw (#21) and adaptive routing (#22) sequenced behind durable evidence

## Validation

- `markdownlint-cli2` on changed Markdown
- `./scripts/validate.sh`

## Follow-up

The next implementation target is #54. This PR does not tag a release or reinstall hosts.