### PR TITLE
docs(roadmap): track next durable runtime slices

### DIFF
--- a/.forge/tasks/0020-portable-backend-conformance.md
+++ b/.forge/tasks/0020-portable-backend-conformance.md
@@ -1,7 +1,7 @@
 ---
 id: 0020
 title: Define portable backend adapter and conformance contract
-status: in-progress
+status: done
 agent: architect
 model: opus
 depends_on: [0019]
@@ -30,7 +30,7 @@ privacy, or offline evidence.
       cases and are reproducible offline.
 - [x] No adapter claims exactly-once provider execution without an idempotent provider contract.
 - [x] Schemas, CLI inspection, docs, fixtures, and release projections pass locally.
-- [ ] Hosted checks pass on the PR and the merged release surface.
+- [x] Hosted checks pass on the PR and the merged release surface.
 
 ## Research decisions
 
@@ -53,7 +53,8 @@ so results remain reproducible across SQLite page metadata changes.
 
 ## Verification
 
-Research is recorded on GitHub issue #58. Implementation and the cross-backend fixture matrix
-pass locally: both adapters report 12/12 passed, focused backend/release tests pass, capability
-compilation/rendering is current, and `bash scripts/validate.sh` plus Ruff pass. Hosted workflow
-verification and the merge gate remain in progress.
+Research is recorded on GitHub issue #58. PR #64 merged as `a9d2cfb003b6a1f313c22b133a127cc961ec188a`.
+Both adapters report 12/12 conformance cases, the full suite passes with 217 tests, and the
+evaluation suite reports 312/313 with one pre-existing situational-description warning. Ruff,
+validation, capability compilation/rendering, release projections, and the post-merge workflow
+run `30974614529` all pass.

--- a/.forge/tasks/0021-workflow-definition-versioning.md
+++ b/.forge/tasks/0021-workflow-definition-versioning.md
@@ -1,0 +1,39 @@
+---
+id: 0021
+title: Add workflow definition versioning and replay compatibility gates
+status: planned
+agent: architect
+model: opus
+depends_on: [0017, 0020]
+issue: 68
+---
+
+## Goal
+
+Pin every durable run to an immutable workflow and worker definition, then fail closed when
+replay, checkpoint restore, migration, or effect retry is incompatible with that definition.
+
+## Acceptance criteria
+
+- [ ] Runs persist an immutable definition digest, worker/build revision, policy revision, and
+      feature-flag decision digest.
+- [ ] Aliases select new runs only; in-flight runs remain pinned until explicit continue-as-new or
+      a reviewed migration transition.
+- [ ] Compatibility preflight covers replay, checkpoints, migrations, and effect retries.
+- [ ] Stable step identities and idempotency keys are deterministic and tested against replay.
+- [ ] Golden fixtures cover compatible, incompatible, canary, rollback, and retirement paths.
+- [ ] Offline CLI inspection reports the pinned definition and compatibility decision without raw
+      prompts, credentials, tool payloads, or provider responses.
+- [ ] Backend conformance, full validation, and release projections pass.
+
+## Research decisions
+
+- AWS qualified durable invocation versions model the pin for new versus in-progress executions.
+- Determinism and stable step-name guidance makes identity a contract, not an implementation detail.
+- Version rollout must preserve idempotent provider operations; a version pin does not imply
+  exactly-once external execution.
+
+## Verification
+
+Track implementation and release evidence on GitHub issue #68. Promote a failing replay fixture to
+the compatibility corpus before closing the task.

--- a/.forge/tasks/0022-signed-trace-provenance.md
+++ b/.forge/tasks/0022-signed-trace-provenance.md
@@ -1,0 +1,38 @@
+---
+id: 0022
+title: Add signed trace-context and provenance bridge for runtime episodes
+status: planned
+agent: observability-specialist
+model: sonnet
+depends_on: [0018, 0020]
+issue: 65
+---
+
+## Goal
+
+Connect canonical runtime history to portable traces and digest-bound provenance while keeping raw
+prompts, credentials, tool content, and provider bodies out of default evidence.
+
+## Acceptance criteria
+
+- [ ] Version-pinned W3C and OpenTelemetry mappings correlate runs, episodes, effects, waits,
+      provider references, and receipt digests deterministically.
+- [ ] Sensitive and verbose attributes are digest/reference-only by default, with explicit opt-in
+      filtering, truncation, and export controls.
+- [ ] Signed provenance verifies subject, source, policy, and evidence-input digests offline;
+      tampering and malformed trust material fail closed.
+- [ ] Export loss or reordering cannot mutate canonical runtime state.
+- [ ] Tests cover privacy regressions, malformed context, key rotation, and reproducible output.
+- [ ] Retention, redaction, key custody, and incident response are documented.
+
+## Research decisions
+
+- OpenTelemetry semantic conventions are versioned and GenAI content fields are treated as
+  potentially sensitive.
+- W3C Trace Context is a correlation envelope, not a state-transition authority.
+- SLSA-style subject digests and verification policy provide the provenance boundary.
+
+## Verification
+
+Track implementation and release evidence on GitHub issue #65. Keep the event history and receipt
+verifier authoritative if an exporter is unavailable.

--- a/.forge/tasks/0023-distributed-watch-recovery.md
+++ b/.forge/tasks/0023-distributed-watch-recovery.md
@@ -1,0 +1,39 @@
+---
+id: 0023
+title: Add distributed revision and watch recovery adapter
+status: planned
+agent: concurrency-engineer
+model: sonnet
+depends_on: [0020]
+issue: 67
+---
+
+## Goal
+
+Add an etcd-first distributed adapter that preserves Forge ordering, fencing, recovery, and privacy
+contracts across revisions, watches, leases, snapshots, reconnects, and compaction.
+
+## Acceptance criteria
+
+- [ ] The adapter negotiates consistency, revision, watch, lease, snapshot, and compaction
+      capabilities before a run starts.
+- [ ] Required state transitions use strict-serializable transactions; observations cannot mutate
+      canonical state unless their cursor is verified.
+- [ ] Gaps, stale cursors, reconnects, and compaction recover from a verified snapshot plus replay
+      or fail closed with evidence.
+- [ ] Duplicate and out-of-order notifications preserve one canonical history.
+- [ ] Remote IDs, revisions, and CloudEvents remain reference-only adapter evidence.
+- [ ] Offline fault simulation and the full shared conformance matrix pass.
+- [ ] Snapshot retention, quorum loss, compaction windows, and operator recovery are documented.
+
+## Research decisions
+
+- etcd strict-serializable writes and monotonic revisions are useful guarantees, while watch
+  cursors and compaction require explicit recovery logic.
+- Remote revisions never replace Forge event identity or hash-chain ordering.
+- Provider execution remains at-least-once and idempotency-bound.
+
+## Verification
+
+Track implementation and release evidence on GitHub issue #67. A live cluster is optional for the
+first test pass; deterministic local watch faults are required.

--- a/.forge/tasks/0024-deterministic-chaos-shrinking.md
+++ b/.forge/tasks/0024-deterministic-chaos-shrinking.md
@@ -1,0 +1,39 @@
+---
+id: 0024
+title: Add deterministic chaos and schedule-shrinking harness
+status: planned
+agent: test-engineer
+model: sonnet
+depends_on: [0019, 0020]
+issue: 66
+---
+
+## Goal
+
+Explore durable runtime interleavings with seedable schedules and shrink failures to minimal,
+offline-replayable counterexamples.
+
+## Acceptance criteria
+
+- [ ] A schedule DSL covers commit crashes, duplicate delivery, stale workers, lease expiry,
+      wait/signal races, checkpoint corruption, cursor gaps, compaction, provider timeout, and
+      ambiguous commit.
+- [ ] The same schedule runs against every backend and compares history, outcome, receipts, and
+      privacy evidence.
+- [ ] Invariants cover hash chains, event/effect atomicity, fencing, dedupe, cancellation,
+      recovery, replay, and privacy.
+- [ ] Shrinking emits a digest-only minimal schedule that preserves failure classification.
+- [ ] CI runs a bounded deterministic seed corpus without wall-clock or network dependence.
+- [ ] CLI supports generate, run, shrink, replay, and inspect.
+- [ ] Regression schedules are promoted into conformance and release evidence.
+
+## Research decisions
+
+- Retry and replay behavior must assume repeated operations and stable idempotency keys.
+- A deterministic schedule is high-signal coverage, not a claim of exhaustive interleavings.
+- Failure artifacts must omit raw prompts, credentials, provider bodies, and host-specific paths.
+
+## Verification
+
+Track implementation and release evidence on GitHub issue #66. Preserve the seed and contract
+digest for every promoted regression.

--- a/.forge/tasks/README.md
+++ b/.forge/tasks/README.md
@@ -21,4 +21,8 @@
 | 0017 | Add checkpointed recovery and fail-closed migrations | done | migration-specialist | sonnet | 0015, 0016 |
 | 0018 | Add verifiable execution lineage and receipt integrity | done | observability-specialist | sonnet | 0017 |
 | 0019 | Add durable human-input waits, signals, and cancellation | done | orchestration-specialist | sonnet | 0018 |
-| 0020 | Define portable backend adapter and conformance contract | in-progress | architect | opus | 0019 |
+| 0020 | Define portable backend adapter and conformance contract | done | architect | opus | 0019 |
+| 0021 | Add workflow definition versioning and replay compatibility gates | planned | architect | opus | 0017, 0020 |
+| 0022 | Add signed trace-context and provenance bridge for runtime episodes | planned | observability-specialist | sonnet | 0018, 0020 |
+| 0023 | Add distributed revision and watch recovery adapter | planned | concurrency-engineer | sonnet | 0020 |
+| 0024 | Add deterministic chaos and schedule-shrinking harness | planned | test-engineer | sonnet | 0019, 0020 |

--- a/docs/runtime-roadmap.md
+++ b/docs/runtime-roadmap.md
@@ -33,6 +33,9 @@ workflows, and telemetry remain adapters or evidence surfaces.
 | Human interaction | MCP Tasks defines `input_required`, TTL, polling hints, cancellation, authorization binding, limits, and audit expectations; provider task state is not enough. | Model waits and signals in Forge history, then expose MCP Tasks as an adapter. |
 | Evidence | OpenTelemetry provides versioned agent/workflow/tool vocabulary; W3C Trace Context carries portable correlation; SLSA and in-toto bind evidence to immutable subjects and resolved inputs. | Add a privacy-safe, digest-bound episode lineage and receipt verifier with pinned mappings, without replacing canonical history or GitHub release attestations. |
 | GitHub delivery | GitHub Merge Queue validates checks on the latest target plus queued changes and requires `merge_group` reporting. | Preserve SHA-bound stack plans, queue-event correlation, explicit approval, and indeterminate stop states. |
+| Definition rollout | AWS durable execution pins qualified versions and requires deterministic replay; Temporal uses worker-version compatibility and reachability signals. | Pin every run to an immutable definition/build digest; aliases affect new runs only, and incompatible replay fails closed or crosses an explicit continue-as-new boundary. |
+| Distributed recovery | etcd separates strict-serializable transactions from watch delivery, revisions, and compaction behavior. | Treat remote revisions as adapter evidence, persist cursors, recover from verified snapshots plus replay, and fail closed on cursor loss or ambiguous boundaries. |
+| Reliability testing | Durable systems expose correctness through idempotency and event history, but race failures depend on interleaving. | Add deterministic schedules, minimized counterexamples, invariant checks, and a bounded seed corpus before claiming backend portability at scale. |
 
 ## Release sequence
 
@@ -56,19 +59,22 @@ workflows, and telemetry remain adapters or evidence surfaces.
    This slice adds checkpoint-before-input waits, digest-bound submissions and signals, explicit
    expiry outcomes, sticky cancellation evidence, and an MCP Tasks projection over Forge state.
 
-### In progress
-
-1. [#58 Portable backend adapter and conformance](https://github.com/AlisinaDevelo/md-files/issues/58)
-
-This slice will make backend portability a negotiated semantic contract rather than a shared CRUD
-interface. Research is focused on consistency levels, revision/cursor mapping, ambiguous commit
-classification, deterministic fault injection, and cross-backend conformance fixtures.
+5. [#58 Portable backend adapter and conformance](https://github.com/AlisinaDevelo/md-files/issues/58)
+   This slice makes backend portability a negotiated semantic contract rather than a shared CRUD
+   interface. Both the SQLite/WAL reference backend and deterministic in-memory fault backend pass
+   the same 12-case matrix, including ambiguous commits, adapter evidence, restore, migration,
+   and privacy boundaries.
 
 ### Next runtime slices
 
 These issues are the minimum credible v4 runtime contract. They are intentionally separate:
 recovery, evidence, interaction, and backend portability have different failure modes and
 must remain independently reviewable.
+
+- [#68 Workflow definition versioning and replay compatibility](https://github.com/AlisinaDevelo/md-files/issues/68)
+- [#67 Distributed revision/watch recovery](https://github.com/AlisinaDevelo/md-files/issues/67)
+- [#66 Deterministic chaos and schedule shrinking](https://github.com/AlisinaDevelo/md-files/issues/66)
+- [#65 Signed trace-context and provenance bridge](https://github.com/AlisinaDevelo/md-files/issues/65)
 
 ### Later integrations
 


### PR DESCRIPTION
## Summary\n\n- mark portable backend conformance (#58) complete in the local Forge ledger\n- add local tasks for versioning, provenance, distributed watch recovery, and deterministic chaos\n- update the durable runtime roadmap and link the research-backed GitHub issues (#65-#68)\n\n## Verification\n\n- bash scripts/validate.sh\n- git diff --check\n\nCloses #58