### PR TITLE
docs(roadmap): record definition pinning release

### DIFF
--- a/.forge/tasks/0021-workflow-definition-versioning.md
+++ b/.forge/tasks/0021-workflow-definition-versioning.md
@@ -1,7 +1,7 @@
 ---
 id: 0021
 title: Add workflow definition versioning and replay compatibility gates
-status: planned
+status: done
 agent: architect
 model: opus
 depends_on: [0017, 0020]
@@ -15,16 +15,16 @@ replay, checkpoint restore, migration, or effect retry is incompatible with that
 
 ## Acceptance criteria
 
-- [ ] Runs persist an immutable definition digest, worker/build revision, policy revision, and
+- [x] Runs persist an immutable definition digest, worker/build revision, policy revision, and
       feature-flag decision digest.
-- [ ] Aliases select new runs only; in-flight runs remain pinned until explicit continue-as-new or
+- [x] Aliases select new runs only; in-flight runs remain pinned until explicit continue-as-new or
       a reviewed migration transition.
-- [ ] Compatibility preflight covers replay, checkpoints, migrations, and effect retries.
-- [ ] Stable step identities and idempotency keys are deterministic and tested against replay.
-- [ ] Golden fixtures cover compatible, incompatible, canary, rollback, and retirement paths.
-- [ ] Offline CLI inspection reports the pinned definition and compatibility decision without raw
+- [x] Compatibility preflight covers replay, checkpoints, migrations, and effect retries.
+- [x] Stable step identities and idempotency keys are deterministic and tested against replay.
+- [x] Golden fixtures cover compatible, incompatible, canary, rollback, and retirement paths.
+- [x] Offline CLI inspection reports the pinned definition and compatibility decision without raw
       prompts, credentials, tool payloads, or provider responses.
-- [ ] Backend conformance, full validation, and release projections pass.
+- [x] Backend conformance, full validation, and release projections pass.
 
 ## Research decisions
 
@@ -35,5 +35,12 @@ replay, checkpoint restore, migration, or effect retry is incompatible with that
 
 ## Verification
 
-Track implementation and release evidence on GitHub issue #68. Promote a failing replay fixture to
-the compatibility corpus before closing the task.
+- PR [#70](https://github.com/AlisinaDevelo/md-files/pull/70) merged as
+  `79a8feb4883f9c79185d1b073c9e1d0dce45c83b` and closed issue #68.
+- `228 passed`; definition/runtime focused coverage is 34 tests.
+- Both portable backends pass 12/12 conformance cases.
+- Ruff, `scripts/validate.sh`, capability compilation/projections, and reproducible release
+  surfaces pass; static eval is 312/313 with the existing one situational-description warning.
+- Hosted main CI run
+  [30976592398](https://github.com/AlisinaDevelo/md-files/actions/runs/30976592398) is green,
+  including host/Codex validation and release packaging.

--- a/.forge/tasks/README.md
+++ b/.forge/tasks/README.md
@@ -22,7 +22,7 @@
 | 0018 | Add verifiable execution lineage and receipt integrity | done | observability-specialist | sonnet | 0017 |
 | 0019 | Add durable human-input waits, signals, and cancellation | done | orchestration-specialist | sonnet | 0018 |
 | 0020 | Define portable backend adapter and conformance contract | done | architect | opus | 0019 |
-| 0021 | Add workflow definition versioning and replay compatibility gates | planned | architect | opus | 0017, 0020 |
+| 0021 | Add workflow definition versioning and replay compatibility gates | done | architect | opus | 0017, 0020 |
 | 0022 | Add signed trace-context and provenance bridge for runtime episodes | planned | observability-specialist | sonnet | 0018, 0020 |
 | 0023 | Add distributed revision and watch recovery adapter | planned | concurrency-engineer | sonnet | 0020 |
 | 0024 | Add deterministic chaos and schedule-shrinking harness | planned | test-engineer | sonnet | 0019, 0020 |

--- a/docs/runtime-roadmap.md
+++ b/docs/runtime-roadmap.md
@@ -15,8 +15,9 @@ workflows, and telemetry remain adapters or evidence surfaces.
   inbox dedupe, and reference-only payload checks.
 - The verifiable lineage and receipt-integrity slice in #56 is implemented and merged; it adds
   offline evidence verification without making telemetry the source of truth.
-- The wait-aware runtime uses database schema v3; v2 checkpoints remain readable evidence but
-  are excluded from restore until a v3 checkpoint is created after migration.
+- The wait-aware runtime now uses database schema v4; v2/v3 checkpoints remain readable evidence
+  but are excluded from restore until a v4 checkpoint is created after migration. v3-to-v4 adds
+  deterministic legacy definition descriptors without rewriting canonical event rows.
 - The current release remains 3.6.0. The transactional effect boundary is documented under
   `Unreleased`; no new tag should claim it until release validation is repeated.
 - The current stack delivery path already records head/base SHAs, guards mutations, handles
@@ -65,13 +66,18 @@ workflows, and telemetry remain adapters or evidence surfaces.
    the same 12-case matrix, including ambiguous commits, adapter evidence, restore, migration,
    and privacy boundaries.
 
+6. [#68 Workflow definition versioning and replay compatibility](https://github.com/AlisinaDevelo/md-files/issues/68)
+   This slice pins workflow code/schema, worker builds, policy and feature-flag decisions to an
+   immutable descriptor. Replay, restore, migration, and effect retry fail closed unless the
+   candidate declares compatibility; aliases affect new runs only, with offline canary, redirect,
+   rollback, retirement, and continue-as-new evidence.
+
 ### Next runtime slices
 
 These issues are the minimum credible v4 runtime contract. They are intentionally separate:
 recovery, evidence, interaction, and backend portability have different failure modes and
 must remain independently reviewable.
 
-- [#68 Workflow definition versioning and replay compatibility](https://github.com/AlisinaDevelo/md-files/issues/68)
 - [#67 Distributed revision/watch recovery](https://github.com/AlisinaDevelo/md-files/issues/67)
 - [#66 Deterministic chaos and schedule shrinking](https://github.com/AlisinaDevelo/md-files/issues/66)
 - [#65 Signed trace-context and provenance bridge](https://github.com/AlisinaDevelo/md-files/issues/65)


### PR DESCRIPTION
## What changed

- Mark Forge task 0021 complete with implementation, test, conformance, release, and hosted CI evidence.
- Move workflow definition versioning (#68) into the completed runtime slices.
- Update the runtime baseline to database schema v4 and keep #67, #66, and #65 as the next independent slices.

Implementation: #70
Post-merge CI: https://github.com/AlisinaDevelo/md-files/actions/runs/30976592398