### PR TITLE
feat(testing): add deterministic chaos schedule harness

### DIFF
--- a/.forge/tasks/0024-deterministic-chaos-shrinking.md
+++ b/.forge/tasks/0024-deterministic-chaos-shrinking.md
@@ -48,5 +48,5 @@ Implementation and release evidence:
 - Backend-scoped `expected_failure` predicates fail closed when a classified regression disappears
   or changes failure class.
 - Seeds `6601`, `6602`, and `6603` pass the bounded corpus with no network or wall-clock reads.
-- The focused chaos suite passes six tests; shrink tests preserve the `terminal_outcome_mismatch`
+- The focused chaos suite passes eight tests; shrink tests preserve the `terminal_outcome_mismatch`
   failure class while removing two irrelevant actions.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ maximize the efficacy of LLMs in software engineering.**
 [![Agents](https://img.shields.io/badge/agents-20-8b5cf6.svg)](plugins/forge/agents/)
 [![Skills](https://img.shields.io/badge/skills-25-06b6d4.svg)](plugins/forge/skills/)
 [![Commands](https://img.shields.io/badge/commands-22-22c55e.svg)](plugins/forge/commands/)
-[![Tests](https://img.shields.io/badge/tests-398%20passing-success.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-400%20passing-success.svg)](tests/)
 [![Prompt evals](https://img.shields.io/badge/prompt%20evals-333%2F334%20checks-success.svg)](evals/)
 
 </div>
@@ -88,7 +88,7 @@ proven method, scoped tools, and guardrails. Forge encodes that scaffolding:
   deterministically, without relying on the model to remember.
 - **Proven, not asserted.** A real eval harness scores prompts and high-risk behavior
   contracts (333/334 deterministic checks, one warning, plus cross-host scenarios and an opt-in
-  LLM judge); 398 tests cover safety hooks, task sync, receipts, durable runtime replay, external effect
+  LLM judge); 400 tests cover safety hooks, task sync, receipts, durable runtime replay, external effect
   delivery, doctor, policy,
   stacks, marketplace readiness, capability graph, rendering, semantic evidence, and conformance. Run
   them yourself — `just check`.

--- a/plugins/forge/skills/orchestration/scripts/forge-chaos.py
+++ b/plugins/forge/skills/orchestration/scripts/forge-chaos.py
@@ -462,7 +462,7 @@ def _handle_wait_signal(adapter: Any, action: Mapping[str, Any], index: int, con
     state = adapter.state(run_id)
     _assert(signal["event_type"] == "signal.received", "wait_signal_race", "signal was not recorded")
     _assert(submission["event_type"] == "wait.input_submitted", "wait_signal_race", "input was not recorded")
-    _assert(state["waits"][wait["payload"]["wait_id"]]["status"] == "submitted", "lost_cancellation", "wait did not resume after signal/input race")
+    _assert(state["waits"][wait["payload"]["wait_id"]]["status"] == "submitted", "wait_signal_race", "wait did not resume after signal/input race")
     return {"outcome": "resumed", "history_digest": digest(adapter.history(run_id)), "state_digest": digest(state)}
 
 
@@ -853,6 +853,15 @@ def compare_results(schedule: Mapping[str, Any], results: list[Mapping[str, Any]
     for candidate in results[1:]:
         candidate_actions = {item["action_id"]: item for item in candidate["canonical"]["actions"]}
         candidate_runs = {item["run_id"]: item for item in candidate["canonical"]["runs"]}
+        for action_id in sorted(set(candidate_actions) - set(baseline_actions)):
+            mismatches.append(
+                {
+                    "action_id": action_id,
+                    "reason_ref": digest(
+                        {"kind": "unexpected_action", "backend": candidate["backend"]["backend_id"]}
+                    ),
+                }
+            )
         for action_id, expected in baseline_actions.items():
             actual = candidate_actions.get(action_id)
             if actual is None:
@@ -877,6 +886,15 @@ def compare_results(schedule: Mapping[str, Any], results: list[Mapping[str, Any]
                 and expected["evidence_digest"] != actual["evidence_digest"]
             ):
                 mismatches.append({"action_id": action_id, "reason_ref": digest({"kind": "evidence", "expected": expected["evidence_digest"], "actual": actual["evidence_digest"]})})
+        for run_id in sorted(set(candidate_runs) - set(baseline_runs)):
+            mismatches.append(
+                {
+                    "run_id": run_id,
+                    "reason_ref": digest(
+                        {"kind": "unexpected_run", "backend": candidate["backend"]["backend_id"]}
+                    ),
+                }
+            )
         for run_id, expected in baseline_runs.items():
             actual = candidate_runs.get(run_id)
             if actual is None:

--- a/scripts/forge-chaos.py
+++ b/scripts/forge-chaos.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Convenience entry point for the bundled Forge chaos harness."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+TARGET = (
+    Path(__file__).resolve().parents[1]
+    / "plugins"
+    / "forge"
+    / "skills"
+    / "orchestration"
+    / "scripts"
+    / "forge-chaos.py"
+)
+
+if __name__ == "__main__":
+    runpy.run_path(str(TARGET), run_name="__main__")

--- a/tests/test_forge_chaos.py
+++ b/tests/test_forge_chaos.py
@@ -58,6 +58,72 @@ def test_same_schedule_passes_all_backends_with_explicit_degradation():
     assert all(item["status"] != "failed" for result_item in result["results"] for item in result_item["actions"])
 
 
+def test_compare_results_rejects_unexpected_actions_and_runs():
+    module = load_module()
+    schedule = module.make_schedule(
+        7002,
+        [{"action_id": "start", "kind": "start_run", "run_id": "run"}],
+    )
+    baseline = module.run_schedule(schedule, "memory")
+
+    extra_action = json.loads(json.dumps(baseline))
+    extra_action["canonical"]["actions"].append(
+        {
+            "action_id": "unexpected-action",
+            "kind": "start_run",
+            "status": "passed",
+            "outcome": "accepted",
+            "failure_class": None,
+            "evidence_digest": None,
+        }
+    )
+    extra_run = json.loads(json.dumps(baseline))
+    extra_run["canonical"]["runs"].append(
+        {
+            "run_id": "unexpected-run",
+            "history_digest": module.digest([]),
+            "state_digest": module.digest({}),
+            "receipt_digest": module.digest([]),
+            "effect_digest": module.digest([]),
+            "status": "running",
+        }
+    )
+
+    comparison = module.compare_results(schedule, [baseline, extra_action, extra_run])
+
+    assert comparison["status"] == "failed"
+    assert {item.get("action_id") for item in comparison["mismatches"]} >= {"unexpected-action"}
+    assert {item.get("run_id") for item in comparison["mismatches"]} >= {"unexpected-run"}
+
+
+def test_wait_signal_invariant_uses_wait_signal_failure_class(monkeypatch):
+    module = load_module()
+
+    class Runtime:
+        def receive_signal(self, *args, **kwargs):
+            return {"event_type": "signal.received"}
+
+        def submit_input(self, *args, **kwargs):
+            return {"event_type": "wait.input_submitted"}
+
+    class Adapter:
+        runtime = Runtime()
+
+        def state(self, run_id):
+            return {"waits": {f"{run_id}:wait": {"status": "waiting"}}}
+
+    monkeypatch.setattr(
+        module,
+        "_prepare_wait",
+        lambda adapter, run_id, index: {"payload": {"wait_id": f"{run_id}:wait"}},
+    )
+
+    with pytest.raises(module.ChaosInvariantError) as error:
+        module._handle_wait_signal(Adapter(), {"run_id": "run"}, 0, set())
+
+    assert error.value.failure_class == "wait_signal_race"
+
+
 def test_shrinker_removes_irrelevant_actions_and_preserves_failure_class():
     module = load_module()
     schedule = module.make_schedule(


### PR DESCRIPTION
## Summary

- Restore the documented `scripts/forge-chaos.py` root entrypoint so the capability graph and runtime docs resolve to an executable command.
- Classify a failed wait/signal invariant as `wait_signal_race`, not `lost_cancellation`.
- Fail backend comparison closed when a candidate emits an unexpected action or run, with digest-only mismatch references.
- Add focused regression coverage and align the published test-count evidence.

## Verification

All evidence below was run locally against commit `e76e5a635928fde98e872dffc8c9bb9d22fc528b`.

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/test_forge_chaos.py -q` - 8 passed
- `./scripts/local-release-check.sh` - passed
- Full suite - 400 passed
- Static eval - 333/334 passed, 1 warning, 0 failures
- Cross-host scenarios - 12 passed, 0 failed, 0 flaky
- Backend conformance and deterministic chaos corpus - passed
- Ruff, Python compilation, Markdown lint, ShellCheck, plugin validation - passed
- Two byte-identical release builds and offline release/Codex/marketplace/attestation validation - passed
- Installed candidate replay - 111 files, 25 skills, two identical attempts across 8 cases
- Candidate archive SHA-256: `b1bbacc376c6b027b757eed2ffcfe78f599f94cef8bd608dd7b50847f52d2a37`

The chaos corpus remains bounded, deterministic, digest-only, and offline; this evidence does not claim exhaustive interleaving coverage or live-provider behavior.
