### PR TITLE
docs(tasks): close merged A2A stream task

### DIFF
--- a/.forge/tasks/0051-a2a-stream-evidence.md
+++ b/.forge/tasks/0051-a2a-stream-evidence.md
@@ -1,7 +1,7 @@
 ---
 id: 0051
 title: Add A2A StreamResponse evidence and concurrent-stream checks
-status: review
+status: done
 agent: interoperability-engineer
 model: sonnet
 depends_on: [0020, 0021]
@@ -23,7 +23,7 @@ message, task, concurrent subscription, and push metadata shapes.
 - [x] Push metadata is bound to the task, context, stream, event, and wrapper member.
 - [x] Credentials, raw content, and authority grants fail closed.
 - [x] A deterministic JSONL corpus and focused tests cover valid and hostile cases.
-- [ ] The change is reviewed and merged through the public release workflow.
+- [x] The change is reviewed and merged through the public release workflow.
 
 ## Research decisions
 
@@ -57,3 +57,5 @@ Local evidence recorded 2026-08-20:
 - Reproducible release builds produced 6 byte-identical artifacts; offline release, Codex,
   marketplace, and attestation checks passed.
 - Installed candidate replay passed twice with identical results across 8 cases (111 files, 25 skills).
+- Public release: PR #99 merged at `c046dc39528ea37bef69f3e2d928af1927c5fbc7` from tested head
+  `6001ab2e6b4fe04c2cbbe0c901f612278c9e9675`.

--- a/.forge/tasks/README.md
+++ b/.forge/tasks/README.md
@@ -52,4 +52,4 @@
 | 0048 | Add host-authenticated admission evidence for connected effects | done | security-engineer | standard | 0047 |
 | 0049 | Validate signed A2A Agent Cards as bounded delegation evidence | done | security-engineer | standard | 0048 |
 | 0050 | Add bounded A2A task handoff and lifecycle evidence | done | interoperability-engineer | standard | 0049, 0047, 0048 |
-| 0051 | Add A2A StreamResponse evidence and concurrent-stream checks | review | interoperability-engineer | sonnet | 0020, 0021 |
+| 0051 | Add A2A StreamResponse evidence and concurrent-stream checks | done | interoperability-engineer | sonnet | 0020, 0021 |


### PR DESCRIPTION
## What
Mark the completed A2A StreamResponse evidence task as done in the local Forge ledger and record the merged implementation head.

## Why
The implementation is already merged through PR #99; leaving the task in review makes the local release ledger disagree with the public repository state.

## Verification
- `./scripts/validate.sh`
- `python3 scripts/forge-a2a-stream.py evaluate --corpus tests/fixtures/a2a-stream/v2.jsonl --json`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/test_forge_a2a_stream.py -q` (15 passed)
- `./scripts/local-release-check.sh` (400 tests; release, replay, and offline verification passed)

No runtime or generated files changed.

Closes #97.