### PR TITLE
docs(tasks): reconcile completed capability criteria

### DIFF
--- a/.forge/tasks/0006-capability-ir-v2.md
+++ b/.forge/tasks/0006-capability-ir-v2.md
@@ -14,11 +14,11 @@ semantically typed intermediate representation that can drive multiple host proj
 
 ## Acceptance criteria
 
-- [ ] The graph schema is versioned as v2 and embeds canonical Markdown instructions.
-- [ ] Components expose identity, trigger, tool, permission, input, output, resource,
+- [x] The graph schema is versioned as v2 and embeds canonical Markdown instructions.
+- [x] Components expose identity, trigger, tool, permission, input, output, resource,
       script, eval, and host-extension fields.
-- [ ] Import remains deterministic and rejects source drift.
-- [ ] Existing components and eval scenarios are migrated without losing coverage.
+- [x] Import remains deterministic and rejects source drift.
+- [x] Existing components and eval scenarios are migrated without losing coverage.
 
 ## Context
 

--- a/.forge/tasks/0008-adapter-contract-tests.md
+++ b/.forge/tasks/0008-adapter-contract-tests.md
@@ -13,11 +13,11 @@ Make third-party host projection behavior explicit, safe, and independently veri
 
 ## Acceptance criteria
 
-- [ ] The v1 adapter schema validates identifiers, component-kind partitions, paths, and
+- [x] The v1 adapter schema validates identifiers, component-kind partitions, paths, and
       projection naming fields.
-- [ ] Unsafe paths, overlapping native/shim kinds, and unsupported kinds fail closed.
-- [ ] A representative third-party adapter renders native skills and agent/command shims.
-- [ ] Deterministic output and existing cross-host scenarios remain green.
+- [x] Unsafe paths, overlapping native/shim kinds, and unsupported kinds fail closed.
+- [x] A representative third-party adapter renders native skills and agent/command shims.
+- [x] Deterministic output and existing cross-host scenarios remain green.
 
 ## Context
 

--- a/.forge/tasks/0009-compiler-gates-docs.md
+++ b/.forge/tasks/0009-compiler-gates-docs.md
@@ -14,11 +14,11 @@ the graph and renderer together.
 
 ## Acceptance criteria
 
-- [ ] `validate.sh`, `justfile`, CI Ruff scope, and release packaging invoke the renderer.
-- [ ] Capability IR docs describe v2 bodies, adapter contracts, migration, and current
+- [x] `validate.sh`, `justfile`, CI Ruff scope, and release packaging invoke the renderer.
+- [x] Capability IR docs describe v2 bodies, adapter contracts, migration, and current
       release boundaries accurately.
-- [ ] README evidence counts and links match the verified suite.
-- [ ] The focused feature is ready for a reviewable PR with follow-up boundaries stated.
+- [x] README evidence counts and links match the verified suite.
+- [x] The focused feature is ready for a reviewable PR with follow-up boundaries stated.
 
 ## Context
 


### PR DESCRIPTION
## What
Mark the verified acceptance criteria in local tasks 0006, 0008, and 0009 as complete.

## Why
Each task is already marked `status: done` and its implementation notes describe the shipped behavior, but all twelve acceptance boxes remained unchecked. This makes the Forge ledger contradict the release evidence.

## Testing
- `python3 -m pytest tests/test_capability_renderer.py tests/test_capability_diff_migration.py tests/test_release_surface_renderer.py -q` — 10 passed
- `./scripts/validate.sh` — passed
- `python3 evals/run.py` — 333/334 passed, 1 warning, 0 failures
- `./scripts/local-release-check.sh` — 412 passed; security, adapter, conformance, lint, reproducibility, offline release, marketplace, and installed replay gates passed

## Scope
Ledger documentation only. No runtime, plugin, or generated release files changed.