### PR TITLE
docs(release): link OpenAI candidate archive

### DIFF
--- a/docs/openai-agent-plugin-submission.md
+++ b/docs/openai-agent-plugin-submission.md
@@ -32,6 +32,15 @@ statement explicitly keeps these checks offline and free of accounts, credential
 data, and network targets. Archive-bound observations remain alongside those fields so the
 repository evidence can be distinguished from the portal's own test run.
 
+## Candidate release
+
+The current public candidate is [Forge 3.6.0](https://github.com/AlisinaDevelo/md-files/releases/tag/v3.6.0).
+Use its [Codex archive](https://github.com/AlisinaDevelo/md-files/releases/download/v3.6.0/forge-3.6.0-codex.tar.gz)
+and verify it against the published [SHA-256 inventory](https://github.com/AlisinaDevelo/md-files/releases/download/v3.6.0/SHA256SUMS)
+before uploading it. The generated report also records these URLs under
+`submission_materials.listing.candidate_*` alongside the exact source commit and archive
+digest. Do not mix a locally rebuilt archive with evidence generated for the public release.
+
 ## Submission fields
 
 | Field | Repository evidence | External state |

--- a/scripts/build_openai_submission_evidence.py
+++ b/scripts/build_openai_submission_evidence.py
@@ -180,6 +180,7 @@ def _submission_metadata(repo: Path, version: str) -> dict[str, Any]:
     if not isinstance(author.get("name"), str) or not author["name"].strip() or not _https(author.get("url")):
         raise SubmissionEvidenceError("publisher metadata must include a name and HTTPS URL")
 
+    release_root = "https://github.com/AlisinaDevelo/md-files"
     listing = {
         "display_name": interface["displayName"],
         "description": interface["longDescription"],
@@ -190,7 +191,10 @@ def _submission_metadata(repo: Path, version: str) -> dict[str, Any]:
         "privacy_policy_url": interface["privacyPolicyURL"],
         "terms_of_service_url": interface["termsOfServiceURL"],
         "starter_prompts": interface["defaultPrompt"],
-        "release_notes_url": "https://github.com/AlisinaDevelo/md-files/blob/main/CHANGELOG.md",
+        "release_notes_url": f"{release_root}/blob/main/CHANGELOG.md",
+        "candidate_release_url": f"{release_root}/releases/tag/v{version}",
+        "candidate_archive_url": f"{release_root}/releases/download/v{version}/forge-{version}-codex.tar.gz",
+        "candidate_checksums_url": f"{release_root}/releases/download/v{version}/SHA256SUMS",
         "availability": {"status": "pending_external_submission", "scope": "not-yet-entered"},
     }
     for field in (
@@ -199,6 +203,9 @@ def _submission_metadata(repo: Path, version: str) -> dict[str, Any]:
         "privacy_policy_url",
         "terms_of_service_url",
         "release_notes_url",
+        "candidate_release_url",
+        "candidate_archive_url",
+        "candidate_checksums_url",
     ):
         if not _https(listing[field]):
             raise SubmissionEvidenceError(f"listing.{field} must be an absolute HTTPS URL")

--- a/tests/test_openai_submission_evidence.py
+++ b/tests/test_openai_submission_evidence.py
@@ -45,6 +45,14 @@ def test_submission_evidence_has_five_positive_and_three_negative_cases(tmp_path
     assert report["submission_materials"]["publication"]["portal_draft"] == "not_repository_verifiable"
     assert report["submission_materials"]["publication"]["availability_review"] == "public_directory_unverified"
     assert "Project-level portal approval" in report["external_blockers"][0]
+    listing = report["submission_materials"]["listing"]
+    version = report["plugin"]["version"]
+    release_root = "https://github.com/AlisinaDevelo/md-files"
+    assert listing["candidate_release_url"] == f"{release_root}/releases/tag/v{version}"
+    assert listing["candidate_archive_url"] == (
+        f"{release_root}/releases/download/v{version}/forge-{version}-codex.tar.gz"
+    )
+    assert listing["candidate_checksums_url"] == f"{release_root}/releases/download/v{version}/SHA256SUMS"
     candidate = report["candidate"]
     assert candidate["archive_sha256"]
     assert candidate["installation"]["status"] == "pass"


### PR DESCRIPTION
## What
Make the OpenAI submission packet expose the exact public candidate release, Codex archive, and SHA-256 inventory URLs in both its JSON metadata and documentation.

## Why
Refs #82. The submission packet verified the candidate locally but did not directly link the release asset needed for portal upload. This left the issue's archive/version acceptance criterion weaker than the actual evidence.

## How
Add version-derived release, archive, and checksum URLs to `submission_materials.listing`, enforce their exact values in the evidence test, and document the upload/checksum boundary. The packet continues to distinguish repository evidence from external directory publication.

## Testing
- `python3 -m pytest tests/test_openai_submission_evidence.py -q` (3 passed)
- `./scripts/local-release-check.sh` (passed)
- Full suite: 412 passed
- Static eval: 333/334 passed, 1 warning, 0 failures
- Cross-host: 12 passed, 0 failed, 0 flaky, 12 skipped
- Reproducible artifacts: 6 byte-identical
- Installed candidate: 113 files, 25 skills, 8 cases, deterministic replay
- Marketplace smoke: passed

## Notes for reviewers
This does not claim OpenAI directory publication or universal availability. The owner-managed portal submission boundary remains tracked in #82.
