### PR TITLE
chore(release): prepare Forge 3.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "Forge — enterprise-grade agents, orchestration, stacked delivery, catalogs, commands, and hooks for software engineering.",
-    "version": "3.7.0"
+    "version": "3.8.0"
   },
   "plugins": [
     {
       "name": "forge",
       "source": "./plugins/forge",
       "description": "Specialists, orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, GitHub-native stacked delivery, catalogs, commands, and safety hooks.",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "homepage": "https://github.com/AlisinaDevelo/md-files/blob/main/docs/getting-started.md",
       "repository": "https://github.com/AlisinaDevelo/md-files",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [3.8.0] — 2026-08-20
+
+### Added
+
+- **MCP Tasks request admission** - require the exact per-request client capability on every
+  task operation while keeping the adapter local, digest-only, and outside live MCP hosting.
+- **gh-aw runtime profiles and MCP Gateway admission** - bind sandbox runtime selection and
+  bounded gateway configuration to the versioned firewall policy, native fields, and provider
+  evidence without accepting credentials or launching external infrastructure.
+
 ## [3.7.0] — 2026-08-20
 
 ### Added
@@ -355,7 +365,8 @@ plugin under `plugins/forge/`.
 - **Docs** — getting started, usage patterns, architecture, design rationale, and CI &
   headless usage guides.
 
-[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.7.0...HEAD
+[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.8.0...HEAD
+[3.8.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.8.0
 [3.7.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.7.0
 [3.6.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.6.0
 [3.5.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.5.0

--- a/data/capabilities.json
+++ b/data/capabilities.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/AlisinaDevelo/md-files/schema/capabilities/v2",
   "schema_version": 2,
   "project": "forge",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "source_contract": {
     "root": "plugins/forge",
     "encoding": "utf-8",

--- a/docs/marketplace-readiness.md
+++ b/docs/marketplace-readiness.md
@@ -8,11 +8,11 @@ accepted a public directory submission.
 
 | Surface | Current state | Evidence or next action |
 |---|---|---|
-| GitHub repository marketplace | Available | Install from `AlisinaDevelo/md-files`; tag `v3.7.0` is the current release candidate. |
+| GitHub repository marketplace | Available | Install from `AlisinaDevelo/md-files`; tag `v3.8.0` is the current release candidate. |
 | Claude Code repository marketplace | Available | `claude plugin marketplace add AlisinaDevelo/md-files` then `claude plugin install forge@forge`. |
 | Codex local/repository marketplace | Available | `codex plugin marketplace add AlisinaDevelo/md-files` then `codex plugin add forge@forge`. |
 | Claude public/curated directory | Not submitted | Do not claim listing or approval; submit only after the checklist below is reviewed. |
-| OpenAI universal Plugin Directory (ChatGPT and Codex) | Project portal approval recorded | Owner-provided evidence dated 2026-08-18 shows Forge 3.6.0 as Approved; the 3.7.0 ZIP is the current candidate; public listing and universal availability are not independently verified. |
+| OpenAI universal Plugin Directory (ChatGPT and Codex) | Project portal approval recorded | Owner-provided evidence dated 2026-08-18 shows Forge 3.6.0 as Approved; the 3.8.0 ZIP is the current candidate; public listing and universal availability are not independently verified. |
 | Agent Skills ecosystem directories | Not submitted | The `.agents` bundle is installable and validated, but no third-party directory approval is claimed. |
 
 The OpenAI universal Plugin Directory and package model are described in [OpenAI's plugin
@@ -82,7 +82,7 @@ Before any external submission, record a dated result for each case in the issue
 | Near-miss request | Unrelated prompts do not invoke a Forge skill solely because they mention code. |
 | Permission boundary | Read-only work does not require mutation approval; GitHub/release effects remain policy-gated. |
 | Clean install | A fresh user can add the documented repository marketplace and install `forge@forge`. |
-| Upgrade | Version `3.7.0` replaces the prior cache entry without stale skill content. |
+| Upgrade | Version `3.8.0` replaces the prior cache entry without stale skill content. |
 | Uninstall | Removing Forge removes the host registration while leaving the user's repository untouched. |
 | Resource loading | Every declared skill, command, hook, asset, and referenced file loads from the cached plugin root. |
 | OpenAI submission evidence | Five positive and three negative skills-only cases are recorded with expected behavior and release notes. |

--- a/docs/openai-agent-plugin-submission.md
+++ b/docs/openai-agent-plugin-submission.md
@@ -35,9 +35,9 @@ repository evidence can be distinguished from the portal's own test run.
 
 ## Candidate release
 
-The current public candidate is [Forge 3.7.0](https://github.com/AlisinaDevelo/md-files/releases/tag/v3.7.0).
-Use its [OpenAI skills-only ZIP](https://github.com/AlisinaDevelo/md-files/releases/download/v3.7.0/forge-3.7.0-openai.zip)
-and verify it against the published [SHA-256 inventory](https://github.com/AlisinaDevelo/md-files/releases/download/v3.7.0/SHA256SUMS)
+The current public candidate is [Forge 3.8.0](https://github.com/AlisinaDevelo/md-files/releases/tag/v3.8.0).
+Use its [OpenAI skills-only ZIP](https://github.com/AlisinaDevelo/md-files/releases/download/v3.8.0/forge-3.8.0-openai.zip)
+and verify it against the published [SHA-256 inventory](https://github.com/AlisinaDevelo/md-files/releases/download/v3.8.0/SHA256SUMS)
 before uploading it. The generated report also records these URLs under
 `submission_materials.listing.candidate_*` alongside the exact source commit and archive
 digest. Do not mix a locally rebuilt archive with evidence generated for the public release.

--- a/docs/openai-agent-plugins.md
+++ b/docs/openai-agent-plugins.md
@@ -31,12 +31,12 @@ The current OpenAI contract requires or recognizes the following surfaces:
 | Surface | Forge state | Evidence |
 |---|---|---|
 | `.codex-plugin/plugin.json` | Present | `plugins/forge/.codex-plugin/plugin.json` |
-| Stable name and strict semver | Passing | `forge`, `3.7.0` |
+| Stable name and strict semver | Passing | `forge`, `3.8.0` |
 | Publisher identity and HTTPS metadata | Present | author, homepage, repository, policy URLs |
 | Skills directory | Present | `skills: ./skills/` and 25 validated skills |
 | Interface metadata | Present | display name, descriptions, category, prompts, capabilities |
 | Directory assets | Present | icon, light logo, dark logo |
-| Skills-only submission ZIP | Passing | `forge-3.7.0-openai.zip`, root manifest and skills tree |
+| Skills-only submission ZIP | Passing | `forge-3.8.0-openai.zip`, root manifest and skills tree |
 | UI screenshots | Intentionally absent | Forge has no custom UI; OpenAI says screenshots are for UI plugins |
 | Codex repository marketplace | Present | `.agents/plugins/marketplace.json` |
 | MCP server and app template | Not included | Not needed for the current skills-only workflow |

--- a/docs/runtime-roadmap.md
+++ b/docs/runtime-roadmap.md
@@ -22,7 +22,7 @@ workflows, and telemetry remain adapters or evidence surfaces.
 - The wait-aware runtime now uses database schema v4; v2/v3 checkpoints remain readable evidence
   but are excluded from restore until a v4 checkpoint is created after migration. v3-to-v4 adds
   deterministic legacy definition descriptors without rewriting canonical event rows.
-- The current release candidate is 3.7.0. The transactional effect boundary is documented
+- The current release candidate is 3.8.0. The transactional effect boundary is documented
   under its release heading and must remain covered by the local release gate.
 - The current stack delivery path already records head/base SHAs, guards mutations, handles
   Merge Queue observation, and receives `merge_group` CI checks. Stacked delivery is a

--- a/plugins/forge/.claude-plugin/plugin.json
+++ b/plugins/forge/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "forge",
   "displayName": "Forge",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "An enterprise-grade Claude Code toolkit: specialists, orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, GitHub-native stacked delivery, commands, and safety hooks.",
   "author": {
     "name": "Alisina Karimi",

--- a/plugins/forge/.codex-plugin/plugin.json
+++ b/plugins/forge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "A Codex engineering toolkit with orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, catalogs, and GitHub-native stacked delivery.",
   "author": {
     "name": "Alisina Karimi",


### PR DESCRIPTION
## Summary

- Align Claude, Codex, marketplace, and generated capability metadata at 3.8.0.
- Record MCP Tasks admission and gh-aw runtime profile changes in the 3.8.0 changelog.
- Advance release-candidate and OpenAI submission references to the next release.

The runtime behavior for this release is already on `main` through PRs #111 and #112; this PR is release metadata and documentation only.

## Local verification

- `./scripts/local-release-check.sh` — `LOCAL_RELEASE_GATE=passed`
- 418 pytest tests passed.
- Static evals: 333/334 passed, 1 warning, 0 failures.
- Trajectory, authority, host-admission, A2A card/task, backend-conformance, and chaos corpora passed.
- Python compilation, Ruff, Markdown lint, skills-ref, strict Claude validation, and ShellCheck passed.
- Two byte-identical release builds; offline release, Codex archive, OpenAI ZIP, marketplace, and attestation checks passed.
- Installed replay: 2 identical attempts, 8 cases, 119 files, 25 skills.
- Local OpenAI candidate ZIP SHA-256: `84e9fb27c18b369832a06db9d8a616374cb118eb1da0934f44539092de19e54b`.

The tag and published assets should be created only after this commit is merged and the final tested head is confirmed.