### PR TITLE
ci: use Node 24 Ruff action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Compile hook, skill, eval, and test scripts
         run: python -m py_compile plugins/forge/hooks/scripts/*.py plugins/forge/skills/*/scripts/*.py scripts/*.py evals/*.py tests/*.py
       - name: Lint with ruff
-        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           args: check plugins/forge/hooks/scripts plugins/forge/skills/policy/scripts plugins/forge/skills/stacked-changes/scripts plugins/forge/skills/doctor/scripts plugins/forge/skills/observability/scripts plugins/forge/skills/task-ledger/scripts plugins/forge/skills/orchestration/scripts scripts/build_release.py scripts/forge-attestation.py scripts/forge-trajectory-evals.py scripts/forge-authority.py scripts/forge-host-admission.py scripts/forge-a2a-card.py scripts/forge-a2a-task.py scripts/build_openai_submission_evidence.py scripts/compile_capabilities.py scripts/render_capabilities.py scripts/diff_capabilities.py scripts/migrate_capabilities.py scripts/validate_codex_plugin.py scripts/verify_release.py scripts/generate_catalog.py scripts/forge-doctor.py scripts/forge-policy.py scripts/forge-receipts.py scripts/forge-runtime.py scripts/forge-lineage.py scripts/forge-provenance.py scripts/forge-gh-aw.py scripts/forge-gh-aw-provider.py scripts/forge-tasks.py scripts/forge-stack-sync.py evals tests
 


### PR DESCRIPTION
## Summary

- Update the pinned `astral-sh/ruff-action` revision from v3 to v4.1.0.
- Use the upstream action revision whose official `action.yml` runs on Node 24.
- Preserve the existing Ruff arguments and lint scope.

Upstream release: https://github.com/astral-sh/ruff-action/releases/tag/v4.1.0

## Verification

- `actionlint .github/workflows/ci.yml` passed.
- `zizmor .github/workflows/ci.yml` reported only pre-existing workflow findings outside this one-line change.
- `PYTHONDONTWRITEBYTECODE=1 FORGE_LOCAL_RELEASE_EVIDENCE=/tmp/forge-ruff-node24-evidence.json ./scripts/local-release-check.sh` passed.
- 418 tests passed; static evals 333/334 passed with 1 warning and 0 failures.
- Security, conformance, reproducibility, archive, attestation, marketplace, and deterministic replay checks passed.