### PR TITLE
ci: lock host CLI installation

### DIFF
--- a/.github/host-cli/package-lock.json
+++ b/.github/host-cli/package-lock.json
@@ -1,0 +1,277 @@
+{
+  "name": "forge-ci-host-clis",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "forge-ci-host-clis",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/claude-code": "2.1.181",
+        "@openai/codex": "0.146.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.181",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.181.tgz",
+      "integrity": "sha512-C8T7H6qDIZLPzc4VChskMfq2nCjV9DU4zLcHtaK9rlQTt+cFCNPyzZ6FbMWiGQsQ9h4Z7nwdSZNhWEMPvfb5/g==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "bin/claude.exe"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.181",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.181",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.181",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.181",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.181",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.181",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.181",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.181"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
+      "version": "2.1.181",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.181.tgz",
+      "integrity": "sha512-nQlFIQyEIWQd7Pj4xET7+Kndm2kwp+kn9z9lbsS5CstMlYHs9ln9zpc/XYOYnsCcvwlSsVarYXQBREi6x/93ZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
+      "version": "2.1.181",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.181.tgz",
+      "integrity": "sha512-3u47rDjARgQboJ8HloeSHJrDphw9HbUV5YPWIi0ODM75Deyrh67GuXF/OroyQHiC4WwoqifGOhJu/KVDLPh5lA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
+      "version": "2.1.181",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.181.tgz",
+      "integrity": "sha512-Xjf3hWeqQ2G3uu+XcOLmqCT4ZbLVsHSohWO4My9XH3NUQaXYoziqU+UWxZx9LGBrNVzckkagznNB0WxG2SY0qA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
+      "version": "2.1.181",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.181.tgz",
+      "integrity": "sha512-HGPB0t6wBLVxI0zQatRkgfvhm2UG0IUbLU8kcbx+9tdX/f1X+RXGw5cyONgnYiNl2+xik9eMpiG06k9DsPtjtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64": {
+      "version": "2.1.181",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.181.tgz",
+      "integrity": "sha512-+hK3EG9VSUrc2goSQOche9AMFr4haz5TXVuF7TDUw2+iIp8bO3tznFpLolg64HRXUhRgaOHwRLdy24qJSozZ9A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
+      "version": "2.1.181",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.181.tgz",
+      "integrity": "sha512-FG3K7I3AnRUVBPZ2ZjQMJ1I/MiWs+RJQPKV0kc+V1oLtQi9hwydBBt/YwfptN4rtUlPTXC1yA98TQMYqpDFHAA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
+      "version": "2.1.181",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.181.tgz",
+      "integrity": "sha512-m7/j+Yt8jq3ngvVkhdSZw/FSbgQkSizHfgBTWzmwTWoITHAt8lzCIj2Y2ioUcMjJ5gQtFCwBCfmuYPOHR564ZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-x64": {
+      "version": "2.1.181",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.181.tgz",
+      "integrity": "sha512-KHeZ3Pzj49UADNrA9vHZ96JQQmGY6y/1SoUdvyfxv5fqKnFGHCk+gUnzY9pVVRD+rSmoc175Te1wikScbX1Esw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0.tgz",
+      "integrity": "sha512-yG3sPWNda/2YAIQIDq9MrrjoCTIQ7rxYM5IasrG3VBcuhCLTkgeg/JzqmJq1V98RE4MJ5jCxDXXQlOjrditFRw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.146.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.146.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.146.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.146.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.146.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.146.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-darwin-arm64.tgz",
+      "integrity": "sha512-nb61yX4r5L6Z0dlC4o3u0GAK1YCd4TUvjaB382bajDoh84V+uv2hTBIVZ++fgXWV9yoeuNrNnNcn7GoTGOe2Tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-darwin-x64.tgz",
+      "integrity": "sha512-hTQR5jy/ObfTf1MDnuJCZJAe+SljKE8DDwQWN6lDFgjsPhMQz852U2tILt8Ei+G5GkQSzemHYKl2AYPwW0Y5xw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-arm64.tgz",
+      "integrity": "sha512-qiYDxkkEFnXG7joadJW6Q+XcgyDXCpGdpa9nk/c+i0gEomur1j7bHvx12NfWWCF/y8Tqri6ay+FLuC2MjdehtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-x64.tgz",
+      "integrity": "sha512-fswvyGprAPCMiOEue/7MKMk7pCjh9kZIJfJX5i9atmfnmGYbYCcUhZsEH9LEP0+0t5xyPqDbfNXY7NSxIVuXxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-win32-arm64.tgz",
+      "integrity": "sha512-EW6zdjDe+SLX2Iw+xymJ5+Pz2+DGexdstfFHXh4Ub+TfJsQPiMjGfZfNaoWgdJ2FsqSIzVKu2+G0KCMGYz2W8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-win32-x64.tgz",
+      "integrity": "sha512-b3lxMYeR0+IhstNo4JjX1P9cPc1xwVcCVkPd1lD1wpWPJ0SBhpIkPczwbu3ZRkJcdyl342+rgyf4DUrbZLdrGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/.github/host-cli/package.json
+++ b/.github/host-cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "forge-ci-host-clis",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@anthropic-ai/claude-code": "2.1.181",
+    "@openai/codex": "0.146.0"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,8 +286,12 @@ jobs:
           while IFS= read -r -d '' skill; do
             npx --yes skills-ref@0.1.5 validate "$skill"
           done < <(find plugins/forge/skills -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
-      - name: Install host CLIs
-        run: npm install --global @anthropic-ai/claude-code@2.1.181 @openai/codex@0.146.0
+      - name: Install host CLIs from lockfile
+        working-directory: .github/host-cli
+        run: |
+          set -euo pipefail
+          npm ci
+          echo "$GITHUB_WORKSPACE/.github/host-cli/node_modules/.bin" >> "$GITHUB_PATH"
       - name: Validate Claude plugin strictly
         run: claude plugin validate --strict plugins/forge
       - name: Validate the exact release candidate archive
@@ -334,8 +338,8 @@ jobs:
     name: OpenSSF Scorecard
     permissions:
       contents: read
-      id-token: write
-      security-events: write
+      id-token: write # Required by Scorecard to publish signed results
+      security-events: write # Required to upload the Scorecard SARIF report
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
     name: Package, attest, and publish
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
+      contents: write # Required to create and upload the GitHub release
+      id-token: write # Required to sign release provenance through GitHub OIDC
+      attestations: write # Required to publish artifact and SBOM attestations
     steps:
       - name: Check out the tagged commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
## What
- install the pinned Claude and Codex CLIs from a committed npm lockfile
- document the Scorecard and release permission rationale

## Why
This removes the ad-hoc package-install audit finding and makes the host-validation dependency graph reproducible.

## Testing
- `./scripts/local-release-check.sh`
- 418 tests; static evals 333/334 with one warning and zero failures
- 7 byte-identical artifacts, offline validators, attestation, and deterministic installed replay passed
- locked Claude 2.1.181 and Codex 0.146.0 binaries passed local smoke checks
- Zizmor `--pedantic`: no findings

## Notes
The full actionlint scan still reports the pre-existing `SC2034` warning at unchanged `release.yml:117`; the changed CI workflow passes actionlint.