### PR TITLE
ci: use release attestation retry counter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,9 @@ jobs:
                 "$@"; then
                 return 0
               fi
-              sleep 10
+              if [[ "$attempt" -lt 12 ]]; then
+                sleep 10
+              fi
             done
             return 1
           }


### PR DESCRIPTION
## What
- use the attestation verification retry counter to skip the final unnecessary sleep

## Why
This keeps the existing twelve-attempt verification behavior while removing the release workflow ShellCheck/actionlint warning about an unused loop variable.

## Testing
- `./scripts/local-release-check.sh`
- 418 tests; static evals 333/334 with one warning and zero failures
- release packaging, byte comparison, offline validators, attestation, and installed replay passed
- `actionlint .github/workflows/release.yml`
- Zizmor `--pedantic`: no findings