### PR TITLE
ci: hash-pin pytest dependencies

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,0 +1,19 @@
+# Keep CI dependencies hash-pinned; update versions and hashes together.
+colorama==0.4.6 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+exceptiongroup==1.3.1 \
+    --hash=sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598
+iniconfig==2.1.0 \
+    --hash=sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760
+packaging==26.3 \
+    --hash=sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
+pluggy==1.6.0 \
+    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+pygments==2.21.0 \
+    --hash=sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9
+pytest==8.4.1 \
+    --hash=sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7
+tomli==2.2.1 \
+    --hash=sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc
+typing-extensions==4.16.0 \
+    --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install pytest
-        run: pip install pytest
+        run: >-
+          python -m pip install --require-hashes --only-binary=:all:
+          -r .github/requirements-ci.txt
       - name: Run hook tests
         run: pytest tests/ -v
 


### PR DESCRIPTION
## Summary

- Replace the mutable pytest install with a hash-locked CI requirements file.
- Include the resolved pytest dependency set and require binary hashes during installation.
- Address the open Scorecard Pinned-Dependencies finding for the CI pip command.

## Verification

- Isolated hash-locked install and `pip check` passed.
- Isolated pytest run: 418 passed.
- `./scripts/local-release-check.sh`: passed on `ec28d5fb4f3c9018c4d3d1cc35a949615421951c`.
- `actionlint` passed.
- `zizmor --pedantic` reported no findings.

No release artifacts or runtime behavior are changed.