### PR TITLE
fix(ci): update pytest security pin

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -11,8 +11,8 @@ pluggy==1.6.0 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
 pygments==2.21.0 \
     --hash=sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9
-pytest==8.4.1 \
-    --hash=sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7
+pytest==9.0.3 \
+    --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9
 tomli==2.2.1 \
     --hash=sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc
 typing-extensions==4.16.0 \


### PR DESCRIPTION
## Summary

- update the hash-pinned CI pytest dependency from 8.4.1 to 9.0.3
- resolve OpenSSF Scorecard alert #9 for PYSEC-2026-1845

## Verification

- Python 3.14.7 hash-locked install and pip check
- 418 pytest tests
- `./scripts/local-release-check.sh`
- actionlint and zizmor

The OSV record identifies pytest 9.0.3 as the first fixed release: https://osv.dev/vulnerability/PYSEC-2026-1845