### PR TITLE
ci: schedule pip dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+  - package-ecosystem: "pip"
+    directory: "/.github"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary

- add the existing `/.github/requirements-ci.txt` manifest to Dependabot
- keep weekly GitHub Actions updates and apply the same cadence to CI pip dependencies

## Verification

- Dependabot YAML parsed and schedule entries validated
- Python 3.14 hash-locked environment
- 418 pytest tests
- `./scripts/local-release-check.sh`
- actionlint and zizmor