### PR TITLE
feat(opencode): add Agent Skills compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Forge Instructions
+
+USE FORGE for software-engineering work. Prefer the available Forge skills for planning,
+implementation, testing, debugging, review, security, and release work when they are
+installed for the host.
+
+## Forge checkout
+
+Forge is a host-neutral collection of engineering skills and small scripts. In a Forge
+checkout, Claude Code and Codex use their native plugin projections, while OpenCode uses
+the Agent Skills projection declared in `opencode.json` and installed by
+`scripts/install-opencode.sh`.
+
+## Change discipline
+
+- In a Forge checkout, read `CONTRIBUTING.md` and the relevant implementation before
+  editing. In another repository, follow that repository's instructions first.
+- Keep changes focused, auditable, and free of secrets or generated output.
+- Preserve host-specific boundaries: Claude hooks and plugin manifests are not assumed to
+  exist in OpenCode.
+- Use the active repository's existing scripts and tests instead of adding parallel
+  abstractions.
+
+## Verification
+
+Run the narrowest relevant checks while developing, then run the complete documented gate
+before release work. In a Forge checkout:
+
+```bash
+./scripts/validate.sh
+python3 -m pytest tests/ -q
+```
+
+For OpenCode discovery, use `opencode debug config` and `opencode debug skill` after
+installing the Agent Skills projection. OpenCode permissions replace Claude lifecycle
+hooks at that host boundary.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🔨 Forge
 
-**An enterprise-grade Claude Code and Codex toolkit — specialized agents,
+**An enterprise-grade Claude Code, Codex, and OpenCode toolkit — specialized agents,
 progressive-disclosure skills, orchestration loops, slash commands, and safety hooks that
 maximize the efficacy of LLMs in software engineering.**
 
@@ -19,8 +19,8 @@ maximize the efficacy of LLMs in software engineering.**
 
 ---
 
-Forge is a curated, batteries-included configuration for [Claude Code](https://docs.claude.com/en/docs/claude-code)
-and a Codex-compatible skill pack. It packages the patterns that make an AI coding agent
+Forge is a curated, batteries-included configuration for [Claude Code](https://docs.claude.com/en/docs/claude-code),
+[Codex](https://github.com/openai/codex), and [OpenCode](https://opencode.ai). It packages the patterns that make an AI coding agent
 genuinely effective — clear role definitions, disciplined methodologies, task ledgers,
 model routing, the right tools for each job, and guardrails that keep it safe — into one
 installable toolkit. Every artifact is plain Markdown or a small, auditable script: no
@@ -118,9 +118,20 @@ codex plugin marketplace add AlisinaDevelo/md-files
 codex plugin add forge@forge
 ```
 
-Repository marketplace installation is available for both hosts. Forge has not been
-submitted to the public Claude or Codex directories; see [Marketplace readiness](docs/marketplace-readiness.md)
-for the dated publication state, publisher surfaces, and submission evidence.
+**OpenCode (Agent Skills and project instructions):**
+
+```bash
+git clone https://github.com/AlisinaDevelo/md-files.git
+cd md-files
+./scripts/install-opencode.sh --copy
+```
+
+See [OpenCode support](docs/opencode.md) for copy, symlink, verification, and host-boundary details.
+
+Repository marketplace installation is available for Claude Code and Codex, while OpenCode
+uses the Agent Skills installer. Forge has not been submitted to the public Claude or Codex
+directories; see [Marketplace readiness](docs/marketplace-readiness.md) for the dated
+publication state, publisher surfaces, and submission evidence.
 
 **As user-level symlinks (Claude agents, skills, commands):**
 
@@ -129,7 +140,7 @@ git clone https://github.com/AlisinaDevelo/md-files.git && cd md-files
 ./scripts/install.sh        # or --copy / --dry-run
 ```
 
-**As `.agents` skills (Codex and Zed):**
+**As `.agents` skills (Codex, Zed, and OpenCode):**
 
 ```bash
 git clone https://github.com/AlisinaDevelo/md-files.git && cd md-files/zed

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
-Forge is a Claude Code toolkit and Codex-compatible skill pack. You can use it several
-ways, from lowest to highest commitment.
+Forge is a Claude Code toolkit and Agent Skills-compatible pack for Codex, Zed, and
+OpenCode. You can use it several ways, from lowest to highest commitment.
 
 ## Option 1 — Install as a Claude Code plugin (recommended)
 
@@ -40,16 +40,26 @@ cd md-files
 ./scripts/install.sh            # symlink (or --copy, or --dry-run)
 ```
 
-## Option 4 — Install `.agents` skills for Codex or Zed
+## Option 4 — Install `.agents` skills for Codex, Zed, or OpenCode
 
 This installs the Forge methodology skills plus specialist and command shims into
-`~/.agents/skills`, which both Zed and this Codex environment can read.
+`~/.agents/skills`, which Codex, Zed, and OpenCode can read.
 
 ```bash
 git clone https://github.com/AlisinaDevelo/md-files.git
 cd md-files/zed
 ./install.sh            # symlink (or --copy, or --dry-run)
 ```
+
+For an OpenCode-only install that does not change Zed configuration, run the repository
+installer from the checkout root:
+
+```bash
+cd md-files
+./scripts/install-opencode.sh --copy
+```
+
+See [OpenCode support](opencode.md) for the installed locations and verification steps.
 
 ## Option 5 — Cherry-pick
 

--- a/docs/marketplace-readiness.md
+++ b/docs/marketplace-readiness.md
@@ -11,6 +11,7 @@ accepted a public directory submission.
 | GitHub repository marketplace | Available | Install from `AlisinaDevelo/md-files`; tag `v3.8.0` is the current release candidate. |
 | Claude Code repository marketplace | Available | `claude plugin marketplace add AlisinaDevelo/md-files` then `claude plugin install forge@forge`. |
 | Codex local/repository marketplace | Available | `codex plugin marketplace add AlisinaDevelo/md-files` then `codex plugin add forge@forge`. |
+| OpenCode Agent Skills | Available | `./scripts/install-opencode.sh --copy`; OpenCode discovers the installed skills from `~/.agents/skills/`. |
 | Claude public/curated directory | Not submitted | Do not claim listing or approval; submit only after the checklist below is reviewed. |
 | OpenAI universal Plugin Directory (ChatGPT and Codex) | Project portal approval recorded | Owner-provided evidence dated 2026-08-18 shows Forge 3.6.0 as Approved; the 3.8.0 ZIP is the current candidate; public listing and universal availability are not independently verified. |
 | Agent Skills ecosystem directories | Not submitted | The `.agents` bundle is installable and validated, but no third-party directory approval is claimed. |

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -1,0 +1,55 @@
+# OpenCode
+
+Forge supports OpenCode through its stable Agent Skills and `AGENTS.md` interfaces. The
+repository does not pretend that Claude plugin hooks or Codex marketplace manifests are
+portable host features.
+
+## Install
+
+From a Forge checkout:
+
+```bash
+./scripts/install-opencode.sh --copy
+```
+
+The installer writes only to the OpenCode-compatible locations:
+
+| Surface | Location | Contents |
+|---|---|---|
+| Global skills | `~/.agents/skills/` | 25 methodology skills, 20 specialist skills, and 22 command skills |
+| Global instructions | `~/.config/opencode/AGENTS.md` | Forge engineering and verification rules |
+
+Use `--symlink` when the checkout should provide live updates, or `--dry-run` to preview
+the exact files. Existing conflicting files are preserved unless `--force` is supplied.
+
+The project-level `opencode.json` also points OpenCode at `plugins/forge/skills`, so a
+fresh checkout exposes the 25 methodology skills without a global install.
+
+## Verify
+
+Restart OpenCode after installation, then run:
+
+```bash
+opencode --version
+opencode debug config
+opencode debug skill
+```
+
+Ask OpenCode to use `orchestration`, `task-ledger`, `iterate-to-done`, or
+`forge-cmd-review` for a relevant request. Skills load on demand rather than injecting
+their full bodies into every prompt.
+
+## Host boundaries
+
+OpenCode does not consume Forge's `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
+or repository marketplace manifests. Claude lifecycle hooks such as destructive-command
+guards, secret scanning, formatting, and notifications also do not run automatically in
+OpenCode. Use OpenCode's permission rules and repository hooks/CI for those controls.
+
+Forge's model labels are guidance, not OpenCode model identifiers. Configure the provider
+and model in OpenCode separately; do not copy Claude or Codex model aliases into an
+OpenCode config.
+
+See the [OpenCode Agent Skills documentation](https://opencode.ai/docs/skills),
+[rules documentation](https://opencode.ai/docs/rules/), and
+[command documentation](https://opencode.ai/docs/commands/) for the host contract.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "skills": {
+    "paths": ["./plugins/forge/skills"]
+  }
+}

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Install Forge's Agent Skills projection for OpenCode.
+#
+# Usage:
+#   ./scripts/install-opencode.sh              # copy skills and instructions
+#   ./scripts/install-opencode.sh --symlink    # link to this checkout
+#   ./scripts/install-opencode.sh --dry-run    # preview the copy
+#   ./scripts/install-opencode.sh --force      # replace conflicting files
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILLS_DEST="${OPENCODE_SKILLS_DIR:-$HOME/.agents/skills}"
+CONFIG_DEST="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+SKILLS_SRC="$REPO_ROOT/plugins/forge/skills"
+AGENTS_SRC="$REPO_ROOT/zed/skills/agents"
+COMMANDS_SRC="$REPO_ROOT/zed/skills/commands"
+INSTRUCTIONS_SRC="$REPO_ROOT/AGENTS.md"
+
+MODE="copy"
+DRY_RUN=false
+FORCE=false
+
+usage() {
+  sed -n '2,10p' "$0"
+}
+
+fail() {
+  printf 'install-opencode: %s\n' "$1" >&2
+  exit 1
+}
+
+run() {
+  if $DRY_RUN; then
+    printf '  [dry-run]'
+    printf ' %q' "$@"
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+install_file() {
+  local source="$1"
+  local target="$2"
+
+  if [[ -L "$target" ]] && [[ "$(readlink "$target")" == "$source" ]]; then
+    return 0
+  fi
+  if [[ -f "$target" ]] && cmp -s "$source" "$target"; then
+    return 0
+  fi
+  if [[ -e "$target" || -L "$target" ]]; then
+    $FORCE || fail "refusing to replace existing file: $target (use --force)"
+    run rm -f "$target"
+  fi
+
+  run mkdir -p "$(dirname "$target")"
+  if [[ "$MODE" == "copy" ]]; then
+    run cp "$source" "$target"
+  else
+    run ln -s "$source" "$target"
+  fi
+}
+
+install_tree() {
+  local source_root="$1"
+  local target_root="$2"
+  local file relative
+
+  [[ -d "$source_root" ]] || fail "missing source directory: $source_root"
+  while IFS= read -r -d '' file; do
+    relative="${file#"$source_root"/}"
+    install_file "$file" "$target_root/$relative"
+  done < <(find "$source_root" -type f -print0 | sort -z)
+}
+
+install_flat_skills() {
+  local source_root="$1"
+  local file name
+
+  [[ -d "$source_root" ]] || fail "missing source directory: $source_root"
+  while IFS= read -r -d '' file; do
+    name="$(basename "$file" .md)"
+    install_file "$file" "$SKILLS_DEST/$name/SKILL.md"
+  done < <(find "$source_root" -maxdepth 1 -type f -name '*.md' -print0 | sort -z)
+}
+
+while (($#)); do
+  case "$1" in
+    --copy) MODE="copy" ;;
+    --symlink) MODE="symlink" ;;
+    --dry-run) DRY_RUN=true ;;
+    --force) FORCE=true ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; fail "unknown option: $1" ;;
+  esac
+  shift
+done
+
+[[ -f "$INSTRUCTIONS_SRC" ]] || fail "missing OpenCode instructions: $INSTRUCTIONS_SRC"
+
+methodology_count="$(find "$SKILLS_SRC" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+agent_count="$(find "$AGENTS_SRC" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')"
+command_count="$(find "$COMMANDS_SRC" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')"
+surface_count=$((methodology_count + agent_count + command_count))
+
+printf 'Installing Forge Agent Skills for OpenCode (%s)\n' "$MODE"
+install_tree "$SKILLS_SRC" "$SKILLS_DEST"
+install_flat_skills "$AGENTS_SRC"
+install_flat_skills "$COMMANDS_SRC"
+install_file "$INSTRUCTIONS_SRC" "$CONFIG_DEST/AGENTS.md"
+printf 'Installed %s Forge skill surfaces under %s\n' "$surface_count" "$SKILLS_DEST"
+printf 'Installed OpenCode instructions at %s/AGENTS.md\n' "$CONFIG_DEST"

--- a/tests/test_opencode_compatibility.py
+++ b/tests/test_opencode_compatibility.py
@@ -37,6 +37,13 @@ def test_opencode_skill_projection_has_expected_surfaces():
         assert "\nname: " in content
         assert "\ndescription: " in content
 
+    doctor_command = (REPO / "zed/skills/commands/forge-cmd-doctor.md").read_text(
+        encoding="utf-8"
+    )
+    assert "python3 ~/.agents/skills/doctor/scripts/forge-doctor.py" in doctor_command
+    assert "python3 plugins/forge/skills/doctor/scripts/forge-doctor.py" in doctor_command
+    assert "python3 scripts/forge-doctor.py" not in doctor_command
+
 
 def test_opencode_installer_copy_projection(tmp_path):
     skills_dir = tmp_path / "skills"
@@ -58,6 +65,11 @@ def test_opencode_installer_copy_projection(tmp_path):
     installed = sorted(skills_dir.glob("*/SKILL.md"))
     assert len(installed) == 67
     assert "Installed 67 Forge skill surfaces" in result.stdout
+    assert (skills_dir / "doctor/scripts/forge-doctor.py").is_file()
+    installed_doctor = (skills_dir / "forge-cmd-doctor/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "~/.agents/skills/doctor/scripts/forge-doctor.py" in installed_doctor
     assert (config_dir / "AGENTS.md").read_text(encoding="utf-8") == (
         REPO / "AGENTS.md"
     ).read_text(encoding="utf-8")

--- a/tests/test_opencode_compatibility.py
+++ b/tests/test_opencode_compatibility.py
@@ -1,0 +1,64 @@
+"""Tests for the OpenCode Agent Skills projection and installer."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+INSTALLER = REPO / "scripts/install-opencode.sh"
+
+
+def test_opencode_config_points_at_methodology_skills():
+    config = json.loads((REPO / "opencode.json").read_text(encoding="utf-8"))
+
+    assert config["$schema"] == "https://opencode.ai/config.json"
+    assert config["skills"]["paths"] == ["./plugins/forge/skills"]
+
+
+def test_opencode_skill_projection_has_expected_surfaces():
+    methodology = sorted(
+        path for path in (REPO / "plugins/forge/skills").iterdir() if path.is_dir()
+    )
+    agents = sorted((REPO / "zed/skills/agents").glob("*.md"))
+    commands = sorted((REPO / "zed/skills/commands").glob("*.md"))
+
+    assert len(methodology) == 25
+    assert len(agents) == 20
+    assert len(commands) == 22
+    assert all((path / "SKILL.md").is_file() for path in methodology)
+
+    for path in [*(path / "SKILL.md" for path in methodology), *agents, *commands]:
+        content = path.read_text(encoding="utf-8")
+        assert content.startswith("---\n")
+        assert "\nname: " in content
+        assert "\ndescription: " in content
+
+
+def test_opencode_installer_copy_projection(tmp_path):
+    skills_dir = tmp_path / "skills"
+    config_dir = tmp_path / "config"
+    env = os.environ.copy()
+    env["OPENCODE_SKILLS_DIR"] = str(skills_dir)
+    env["OPENCODE_CONFIG_DIR"] = str(config_dir)
+
+    result = subprocess.run(
+        ["bash", str(INSTALLER), "--copy"],
+        cwd=REPO,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    installed = sorted(skills_dir.glob("*/SKILL.md"))
+    assert len(installed) == 67
+    assert "Installed 67 Forge skill surfaces" in result.stdout
+    assert (config_dir / "AGENTS.md").read_text(encoding="utf-8") == (
+        REPO / "AGENTS.md"
+    ).read_text(encoding="utf-8")
+    assert not any(path.is_symlink() for path in installed)

--- a/zed/skills/commands/forge-cmd-doctor.md
+++ b/zed/skills/commands/forge-cmd-doctor.md
@@ -1,0 +1,12 @@
+---
+name: forge-cmd-doctor
+description: Run the read-only Forge capability and merge-readiness preflight
+disable-model-invocation: true
+---
+
+Run `python3 scripts/forge-doctor.py` from the repository root with the requested flags.
+Use the `doctor` skill for interpretation.
+
+Report the overall status and the checks that are `warn`, `fail`, or `unknown`. Do not
+repair findings automatically. For JSON consumers, preserve the schema-versioned report
+exactly and explain any skipped network checks.

--- a/zed/skills/commands/forge-cmd-doctor.md
+++ b/zed/skills/commands/forge-cmd-doctor.md
@@ -4,7 +4,11 @@ description: Run the read-only Forge capability and merge-readiness preflight
 disable-model-invocation: true
 ---
 
-Run `python3 scripts/forge-doctor.py` from the repository root with the requested flags.
+Run the read-only Forge doctor script with the requested flags. For a global Agent Skills
+install, use `python3 ~/.agents/skills/doctor/scripts/forge-doctor.py`; from a Forge
+checkout, use `python3 plugins/forge/skills/doctor/scripts/forge-doctor.py`. Do not assume
+that the target repository contains a Forge `scripts/` directory.
+
 Use the `doctor` skill for interpretation.
 
 Report the overall status and the checks that are `warn`, `fail`, or `unknown`. Do not


### PR DESCRIPTION
## Summary
- add a stable OpenCode project config and global-safe AGENTS.md instructions
- add a copy/symlink installer for Forge Agent Skills, specialist skills, and command shims
- document OpenCode boundaries and verify the 67-surface projection, including the doctor command

## Verification
- `./scripts/local-release-check.sh`
- 421 tests passed
- 333/334 static evaluations passed, 1 warning, 0 failures
- offline release, archive, attestation, marketplace, and deterministic installed replay checks passed
- OpenCode 1.18.21 project discovery smoke passed

Hosted checks are not used as acceptance evidence for this change.