### PR TITLE
chore(release): prepare Forge 3.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "Forge — enterprise-grade agents, orchestration, stacked delivery, catalogs, commands, and hooks for software engineering.",
-    "version": "3.8.0"
+    "version": "3.9.0"
   },
   "plugins": [
     {
       "name": "forge",
       "source": "./plugins/forge",
       "description": "Specialists, orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, GitHub-native stacked delivery, catalogs, commands, and safety hooks.",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "homepage": "https://github.com/AlisinaDevelo/md-files/blob/main/docs/getting-started.md",
       "repository": "https://github.com/AlisinaDevelo/md-files",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [3.9.0] — 2026-08-22
+
+### Added
+
+- **OpenCode Agent Skills compatibility** - added stable project configuration, global-safe
+  `AGENTS.md` instructions, a copy/symlink installer, specialist and command projections,
+  and documented host boundaries for OpenCode.
+- **Portable Forge doctor command** - made the `.agents` doctor shim resolve the installed
+  global script or a Forge checkout without assuming the target repository layout.
+
 ## [3.8.0] — 2026-08-20
 
 ### Added
@@ -365,7 +375,8 @@ plugin under `plugins/forge/`.
 - **Docs** — getting started, usage patterns, architecture, design rationale, and CI &
   headless usage guides.
 
-[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.8.0...HEAD
+[Unreleased]: https://github.com/AlisinaDevelo/md-files/compare/v3.9.0...HEAD
+[3.9.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.9.0
 [3.8.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.8.0
 [3.7.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.7.0
 [3.6.0]: https://github.com/AlisinaDevelo/md-files/releases/tag/v3.6.0

--- a/data/capabilities.json
+++ b/data/capabilities.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/AlisinaDevelo/md-files/schema/capabilities/v2",
   "schema_version": 2,
   "project": "forge",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "source_contract": {
     "root": "plugins/forge",
     "encoding": "utf-8",

--- a/docs/marketplace-readiness.md
+++ b/docs/marketplace-readiness.md
@@ -8,12 +8,12 @@ accepted a public directory submission.
 
 | Surface | Current state | Evidence or next action |
 |---|---|---|
-| GitHub repository marketplace | Available | Install from `AlisinaDevelo/md-files`; tag `v3.8.0` is the current release candidate. |
+| GitHub repository marketplace | Available | Install from `AlisinaDevelo/md-files`; tag `v3.9.0` is the current release candidate. |
 | Claude Code repository marketplace | Available | `claude plugin marketplace add AlisinaDevelo/md-files` then `claude plugin install forge@forge`. |
 | Codex local/repository marketplace | Available | `codex plugin marketplace add AlisinaDevelo/md-files` then `codex plugin add forge@forge`. |
 | OpenCode Agent Skills | Available | `./scripts/install-opencode.sh --copy`; OpenCode discovers the installed skills from `~/.agents/skills/`. |
 | Claude public/curated directory | Not submitted | Do not claim listing or approval; submit only after the checklist below is reviewed. |
-| OpenAI universal Plugin Directory (ChatGPT and Codex) | Project portal approval recorded | Owner-provided evidence dated 2026-08-18 shows Forge 3.6.0 as Approved; the 3.8.0 ZIP is the current candidate; public listing and universal availability are not independently verified. |
+| OpenAI universal Plugin Directory (ChatGPT and Codex) | Project portal approval recorded | Owner-provided evidence dated 2026-08-18 shows Forge 3.6.0 as Approved; the 3.9.0 ZIP is the current candidate; public listing and universal availability are not independently verified. |
 | Agent Skills ecosystem directories | Not submitted | The `.agents` bundle is installable and validated, but no third-party directory approval is claimed. |
 
 The OpenAI universal Plugin Directory and package model are described in [OpenAI's plugin
@@ -83,7 +83,7 @@ Before any external submission, record a dated result for each case in the issue
 | Near-miss request | Unrelated prompts do not invoke a Forge skill solely because they mention code. |
 | Permission boundary | Read-only work does not require mutation approval; GitHub/release effects remain policy-gated. |
 | Clean install | A fresh user can add the documented repository marketplace and install `forge@forge`. |
-| Upgrade | Version `3.8.0` replaces the prior cache entry without stale skill content. |
+| Upgrade | Version `3.9.0` replaces the prior cache entry without stale skill content. |
 | Uninstall | Removing Forge removes the host registration while leaving the user's repository untouched. |
 | Resource loading | Every declared skill, command, hook, asset, and referenced file loads from the cached plugin root. |
 | OpenAI submission evidence | Five positive and three negative skills-only cases are recorded with expected behavior and release notes. |

--- a/docs/openai-agent-plugin-submission.md
+++ b/docs/openai-agent-plugin-submission.md
@@ -35,9 +35,9 @@ repository evidence can be distinguished from the portal's own test run.
 
 ## Candidate release
 
-The current public candidate is [Forge 3.8.0](https://github.com/AlisinaDevelo/md-files/releases/tag/v3.8.0).
-Use its [OpenAI skills-only ZIP](https://github.com/AlisinaDevelo/md-files/releases/download/v3.8.0/forge-3.8.0-openai.zip)
-and verify it against the published [SHA-256 inventory](https://github.com/AlisinaDevelo/md-files/releases/download/v3.8.0/SHA256SUMS)
+The current public candidate is [Forge 3.9.0](https://github.com/AlisinaDevelo/md-files/releases/tag/v3.9.0).
+Use its [OpenAI skills-only ZIP](https://github.com/AlisinaDevelo/md-files/releases/download/v3.9.0/forge-3.9.0-openai.zip)
+and verify it against the published [SHA-256 inventory](https://github.com/AlisinaDevelo/md-files/releases/download/v3.9.0/SHA256SUMS)
 before uploading it. The generated report also records these URLs under
 `submission_materials.listing.candidate_*` alongside the exact source commit and archive
 digest. Do not mix a locally rebuilt archive with evidence generated for the public release.
@@ -62,7 +62,7 @@ creating a draft, the submitting organization needs Apps Management write access
 verified individual or business developer identity. The portal currently uses this flow:
 
 1. Create a plugin submission and choose **Skills only**.
-2. Upload the published [OpenAI skills-only ZIP](https://github.com/AlisinaDevelo/md-files/releases/download/v3.8.0/forge-3.8.0-openai.zip), after checking its [SHA-256 inventory](https://github.com/AlisinaDevelo/md-files/releases/download/v3.8.0/SHA256SUMS).
+2. Upload the published [OpenAI skills-only ZIP](https://github.com/AlisinaDevelo/md-files/releases/download/v3.9.0/forge-3.9.0-openai.zip), after checking its [SHA-256 inventory](https://github.com/AlisinaDevelo/md-files/releases/download/v3.9.0/SHA256SUMS).
 3. Complete the listing, publisher, policy URLs, starter prompts, five positive and three
    negative test cases, country availability, and release notes.
 4. Review the complete draft and policy attestations, then choose **Submit for Review**.

--- a/docs/openai-agent-plugins.md
+++ b/docs/openai-agent-plugins.md
@@ -36,12 +36,12 @@ The current OpenAI contract requires or recognizes the following surfaces:
 | Surface | Forge state | Evidence |
 |---|---|---|
 | `.codex-plugin/plugin.json` | Present | `plugins/forge/.codex-plugin/plugin.json` |
-| Stable name and strict semver | Passing | `forge`, `3.8.0` |
+| Stable name and strict semver | Passing | `forge`, `3.9.0` |
 | Publisher identity and HTTPS metadata | Present | author, homepage, repository, policy URLs |
 | Skills directory | Present | `skills: ./skills/` and 25 validated skills |
 | Interface metadata | Present | display name, descriptions, category, prompts, capabilities |
 | Directory assets | Present | icon, light logo, dark logo |
-| Skills-only submission ZIP | Passing | `forge-3.8.0-openai.zip`, root manifest and skills tree |
+| Skills-only submission ZIP | Passing | `forge-3.9.0-openai.zip`, root manifest and skills tree |
 | UI screenshots | Intentionally absent | Forge has no custom UI; OpenAI says screenshots are for UI plugins |
 | Codex repository marketplace | Present | `.agents/plugins/marketplace.json` |
 | MCP server and app template | Not included | Not needed for the current skills-only workflow |

--- a/docs/runtime-roadmap.md
+++ b/docs/runtime-roadmap.md
@@ -22,7 +22,7 @@ workflows, and telemetry remain adapters or evidence surfaces.
 - The wait-aware runtime now uses database schema v4; v2/v3 checkpoints remain readable evidence
   but are excluded from restore until a v4 checkpoint is created after migration. v3-to-v4 adds
   deterministic legacy definition descriptors without rewriting canonical event rows.
-- The current release candidate is 3.8.0. The transactional effect boundary is documented
+- The current release candidate is 3.9.0. The transactional effect boundary is documented
   under its release heading and must remain covered by the local release gate.
 - The current stack delivery path already records head/base SHAs, guards mutations, handles
   Merge Queue observation, and receives `merge_group` CI checks. Stacked delivery is a

--- a/plugins/forge/.claude-plugin/plugin.json
+++ b/plugins/forge/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "forge",
   "displayName": "Forge",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "An enterprise-grade Claude Code toolkit: specialists, orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, GitHub-native stacked delivery, commands, and safety hooks.",
   "author": {
     "name": "Alisina Karimi",

--- a/plugins/forge/.codex-plugin/plugin.json
+++ b/plugins/forge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "A Codex engineering toolkit with orchestration, task ledgers, solve loops, policy-gated effects, async GitHub Stack Merge, catalogs, and GitHub-native stacked delivery.",
   "author": {
     "name": "Alisina Karimi",


### PR DESCRIPTION
## Summary
- prepare the 3.9.0 release metadata after OpenCode Agent Skills support landed
- align Claude, Codex, marketplace, capability, and submission documentation versions
- record the OpenCode-compatible release candidate and changelog entry

## Local verification
- `./scripts/local-release-check.sh` passed at `a73c538602f0d34eaad60d5404e5d38b8045d29e`
- 421 tests passed
- static evals: 333/334 passed, 1 warning, 0 failures
- security, authority, host admission, A2A card/task, and cross-host corpora passed
- 7 byte-identical artifacts; offline release, Codex archive, OpenAI ZIP, attestation, marketplace, and installed replay checks passed
- OpenCode 1.18.21 discovery smoke passed

Hosted checks are not used as acceptance evidence for this release pass.